### PR TITLE
chore: update Kotlin and Gradle versions for compatibility

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.2.10"
+kotlin = "2.2.21"
 kotlinx-serialization = "1.9.0"
 kotlinx-coroutines = "1.10.1"
 mockk = "1.14.5"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Update Kotlin version from 2.2.10 to 2.2.21 and Gradle from 8.14.3 to 9.2.1 to ensure compatibility with newer libraries and features. Keeping dependencies up to date enhances stability and performance, and prepares the project for upcoming development needs.