### PR TITLE
refactor: migrate global singletons to dependency injection

### DIFF
--- a/app/src/main/kotlin/io/sakurasou/hoshizora/Application.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/Application.kt
@@ -40,10 +40,9 @@ fun Application.mainModule() {
             .toLong()
     val clientProxyAddress = environment.config.property("client.proxy.address").getString()
 
+    InstanceCenter.init()
     InstanceCenter.initClient(clientTimeout, clientProxyAddress)
 
-    InstanceCenter.initDao()
-    InstanceCenter.initService()
     configureDatabase()
     configureCache(redisHost, redisPort)
     configureJwt()

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/config/RoutingCenter.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/config/RoutingCenter.kt
@@ -16,18 +16,21 @@ import io.sakurasou.hoshizora.controller.siteInitRoute
 import io.sakurasou.hoshizora.controller.strategyRoute
 import io.sakurasou.hoshizora.controller.systemRoute
 import io.sakurasou.hoshizora.controller.userRoute
-import io.sakurasou.hoshizora.di.InstanceCenter.albumService
-import io.sakurasou.hoshizora.di.InstanceCenter.authService
-import io.sakurasou.hoshizora.di.InstanceCenter.groupService
-import io.sakurasou.hoshizora.di.InstanceCenter.imageService
-import io.sakurasou.hoshizora.di.InstanceCenter.permissionService
-import io.sakurasou.hoshizora.di.InstanceCenter.personalAccessTokenService
-import io.sakurasou.hoshizora.di.InstanceCenter.roleService
-import io.sakurasou.hoshizora.di.InstanceCenter.settingService
-import io.sakurasou.hoshizora.di.InstanceCenter.strategyService
-import io.sakurasou.hoshizora.di.InstanceCenter.systemService
-import io.sakurasou.hoshizora.di.InstanceCenter.userService
+import io.sakurasou.hoshizora.di.inject
 import io.sakurasou.hoshizora.plugins.SiteInitCheckPlugin
+import io.sakurasou.hoshizora.service.album.AlbumService
+import io.sakurasou.hoshizora.service.auth.AuthService
+import io.sakurasou.hoshizora.service.common.CommonService
+import io.sakurasou.hoshizora.service.group.GroupService
+import io.sakurasou.hoshizora.service.image.ImageService
+import io.sakurasou.hoshizora.service.permission.PermissionService
+import io.sakurasou.hoshizora.service.personalAccessToken.PersonalAccessTokenService
+import io.sakurasou.hoshizora.service.role.RoleService
+import io.sakurasou.hoshizora.service.setting.SettingService
+import io.sakurasou.hoshizora.service.strategy.StrategyService
+import io.sakurasou.hoshizora.service.system.SystemService
+import io.sakurasou.hoshizora.service.user.UserService
+import kotlin.getValue
 
 /**
  * @author ShiinaKin
@@ -35,10 +38,23 @@ import io.sakurasou.hoshizora.plugins.SiteInitCheckPlugin
  */
 
 fun Route.apiRoute() {
+    val authService: AuthService by inject()
+    val userService: UserService by inject()
+    val imageService: ImageService by inject()
+    val albumService: AlbumService by inject()
+    val strategyService: StrategyService by inject()
+    val settingService: SettingService by inject()
+    val groupService: GroupService by inject()
+    val roleService: RoleService by inject()
+    val permissionService: PermissionService by inject()
+    val personalAccessTokenService: PersonalAccessTokenService by inject()
+    val commonService by inject<CommonService>()
+    val systemService: SystemService by inject()
+
     route("api") {
         route({ tags("common") }) {
-            siteInitRoute()
-            commonSiteSettingRoute()
+            siteInitRoute(commonService)
+            commonSiteSettingRoute(commonService)
         }
         route {
             install(SiteInitCheckPlugin)

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/controller/AlbumController.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/controller/AlbumController.kt
@@ -36,12 +36,13 @@ import io.sakurasou.hoshizora.extension.pageRequest
 import io.sakurasou.hoshizora.extension.pageRequestSpec
 import io.sakurasou.hoshizora.extension.success
 import io.sakurasou.hoshizora.plugins.AuthorizationPlugin
+import io.sakurasou.hoshizora.service.album.AlbumService
 
 /**
  * @author Shiina Kin
  * 2024/9/9 08:58
  */
-fun Route.albumRoute(albumService: io.sakurasou.hoshizora.service.album.AlbumService) {
+fun Route.albumRoute(albumService: AlbumService) {
     val controller =
         AlbumController(albumService)
     route("album", {
@@ -420,7 +421,7 @@ private fun Route.albumManagePage(controller: AlbumController) {
 private fun ApplicationCall.albumId() = parameters["albumId"]?.toLongOrNull() ?: throw WrongParameterException()
 
 class AlbumController(
-    private val albumService: io.sakurasou.hoshizora.service.album.AlbumService,
+    private val albumService: AlbumService,
 ) {
     suspend fun handleSelfInsert(
         userId: Long,

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/controller/AuthController.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/controller/AuthController.kt
@@ -14,6 +14,8 @@ import io.sakurasou.hoshizora.controller.request.UserInsertRequest
 import io.sakurasou.hoshizora.controller.request.UserLoginRequest
 import io.sakurasou.hoshizora.controller.vo.CommonResponse
 import io.sakurasou.hoshizora.extension.success
+import io.sakurasou.hoshizora.service.auth.AuthService
+import io.sakurasou.hoshizora.service.user.UserService
 import io.swagger.v3.oas.models.media.Schema
 
 /**
@@ -21,8 +23,8 @@ import io.swagger.v3.oas.models.media.Schema
  * 2024/9/12 10:14
  */
 fun Route.authRoute(
-    authService: io.sakurasou.hoshizora.service.auth.AuthService,
-    userService: io.sakurasou.hoshizora.service.user.UserService,
+    authService: AuthService,
+    userService: UserService,
 ) {
     val authController = AuthController(authService, userService)
     route("user", {
@@ -120,8 +122,8 @@ private fun Route.signup(authController: AuthController) {
 }
 
 class AuthController(
-    private val authService: io.sakurasou.hoshizora.service.auth.AuthService,
-    private val userService: io.sakurasou.hoshizora.service.user.UserService,
+    private val authService: AuthService,
+    private val userService: UserService,
 ) {
     suspend fun handleLogin(loginRequest: UserLoginRequest): String = authService.login(loginRequest)
 

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/controller/CommonController.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/controller/CommonController.kt
@@ -3,6 +3,7 @@ package io.sakurasou.hoshizora.controller
 import io.github.smiley4.ktorswaggerui.dsl.routing.get
 import io.github.smiley4.ktorswaggerui.dsl.routing.post
 import io.github.smiley4.ktorswaggerui.dsl.routing.route
+import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsBytes
 import io.ktor.http.ContentType
@@ -21,17 +22,17 @@ import io.sakurasou.hoshizora.constant.REGEX_USERNAME
 import io.sakurasou.hoshizora.controller.request.SiteInitRequest
 import io.sakurasou.hoshizora.controller.vo.CommonResponse
 import io.sakurasou.hoshizora.controller.vo.CommonSiteSetting
-import io.sakurasou.hoshizora.di.InstanceCenter.client
-import io.sakurasou.hoshizora.di.InstanceCenter.commonService
+import io.sakurasou.hoshizora.di.inject
 import io.sakurasou.hoshizora.exception.controller.param.WrongParameterException
 import io.sakurasou.hoshizora.extension.success
 import io.sakurasou.hoshizora.plugins.cache
+import io.sakurasou.hoshizora.service.common.CommonService
 
 /**
  * @author Shiina Kin
  * 2024/9/9 09:03
  */
-fun Route.commonRoute(commonService: io.sakurasou.hoshizora.service.common.CommonService) {
+fun Route.commonRoute(commonService: CommonService) {
     val commonController = CommonController(commonService)
     route({ tags("common") }) {
         cache(cachedNoQueryParamRequest = false) {
@@ -41,7 +42,7 @@ fun Route.commonRoute(commonService: io.sakurasou.hoshizora.service.common.Commo
     }
 }
 
-fun Route.siteInitRoute() {
+fun Route.siteInitRoute(commonService: CommonService) {
     val commonController = CommonController(commonService)
     route {
         install(RequestValidation) {
@@ -80,7 +81,7 @@ fun Route.siteInitRoute() {
     }
 }
 
-fun Route.commonSiteSettingRoute() {
+fun Route.commonSiteSettingRoute(commonService: CommonService) {
     val commonController = CommonController(commonService)
     get("site/setting", {
         description = "fetch common site setting"
@@ -116,6 +117,7 @@ private fun Route.randomFetchImage(commonController: CommonController) {
         if (fileDTO.bytes != null) {
             call.respondBytes(fileDTO.bytes, ContentType.Image.Any)
         } else {
+            val client by inject<HttpClient>()
             call.respondBytes(client.get(fileDTO.url!!).bodyAsBytes(), ContentType.Image.Any)
         }
     }
@@ -142,13 +144,14 @@ private fun Route.anonymousGetImage(commonController: CommonController) {
         if (fileDTO.bytes != null) {
             call.respondBytes(fileDTO.bytes, ContentType.Image.Any)
         } else {
+            val client by inject<HttpClient>()
             call.respondBytes(client.get(fileDTO.url!!).bodyAsBytes(), ContentType.Image.Any)
         }
     }
 }
 
 class CommonController(
-    private val commonService: io.sakurasou.hoshizora.service.common.CommonService,
+    private val commonService: CommonService,
 ) {
     suspend fun handleInit(siteInitRequest: SiteInitRequest) {
         commonService.initSite(siteInitRequest)

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/controller/GroupController.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/controller/GroupController.kt
@@ -24,14 +24,19 @@ import io.sakurasou.hoshizora.controller.vo.GroupAllowedImageType
 import io.sakurasou.hoshizora.controller.vo.GroupPageVO
 import io.sakurasou.hoshizora.controller.vo.GroupVO
 import io.sakurasou.hoshizora.controller.vo.PageResult
-import io.sakurasou.hoshizora.extension.*
+import io.sakurasou.hoshizora.extension.getPrincipal
+import io.sakurasou.hoshizora.extension.id
+import io.sakurasou.hoshizora.extension.pageRequest
+import io.sakurasou.hoshizora.extension.pageRequestSpec
+import io.sakurasou.hoshizora.extension.success
 import io.sakurasou.hoshizora.plugins.AuthorizationPlugin
+import io.sakurasou.hoshizora.service.group.GroupService
 
 /**
  * @author Shiina Kin
  * 2024/9/9 08:58
  */
-fun Route.groupRoute(groupService: io.sakurasou.hoshizora.service.group.GroupService) {
+fun Route.groupRoute(groupService: GroupService) {
     val controller = GroupController(groupService)
     route("group", {
         protected = true
@@ -270,7 +275,7 @@ private fun Route.groupFetchGroupAllowedImageType(controller: GroupController) {
 }
 
 class GroupController(
-    private val groupService: io.sakurasou.hoshizora.service.group.GroupService,
+    private val groupService: GroupService,
 ) {
     suspend fun handleInsertGroup(insertRequest: GroupInsertRequest) {
         groupService.saveGroup(insertRequest)

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/controller/ImageController.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/controller/ImageController.kt
@@ -5,6 +5,7 @@ import io.github.smiley4.ktorswaggerui.dsl.routing.get
 import io.github.smiley4.ktorswaggerui.dsl.routing.patch
 import io.github.smiley4.ktorswaggerui.dsl.routing.post
 import io.github.smiley4.ktorswaggerui.dsl.routing.route
+import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsBytes
 import io.ktor.http.ContentType
@@ -37,7 +38,7 @@ import io.sakurasou.hoshizora.controller.vo.ImageManageVO
 import io.sakurasou.hoshizora.controller.vo.ImagePageVO
 import io.sakurasou.hoshizora.controller.vo.ImageVO
 import io.sakurasou.hoshizora.controller.vo.PageResult
-import io.sakurasou.hoshizora.di.InstanceCenter.client
+import io.sakurasou.hoshizora.di.inject
 import io.sakurasou.hoshizora.exception.controller.param.UnsupportedFileTypeException
 import io.sakurasou.hoshizora.exception.controller.param.WrongParameterException
 import io.sakurasou.hoshizora.extension.getPrincipal
@@ -48,6 +49,7 @@ import io.sakurasou.hoshizora.plugins.AuthorizationPlugin
 import io.sakurasou.hoshizora.plugins.cache
 import io.swagger.v3.oas.models.media.Schema
 import kotlinx.io.readByteArray
+import kotlin.getValue
 
 /**
  * @author ShiinaKin
@@ -257,6 +259,7 @@ private fun Route.imageSelfFileFetch(controller: ImageController) {
             if (imageFileDTO.bytes != null) {
                 call.respondBytes(imageFileDTO.bytes, ContentType.Image.Any)
             } else {
+                val client by inject<HttpClient>()
                 call.respondBytes(client.get(imageFileDTO.url!!).bodyAsBytes(), ContentType.Image.Any)
             }
         }
@@ -284,6 +287,7 @@ private fun Route.imageSelfThumbnailFileFetch(controller: ImageController) {
             if (imageFileDTO.bytes != null) {
                 call.respondBytes(imageFileDTO.bytes, ContentType.Image.Any)
             } else {
+                val client by inject<HttpClient>()
                 call.respondBytes(client.get(imageFileDTO.url!!).bodyAsBytes(), ContentType.Image.Any)
             }
         }
@@ -472,6 +476,7 @@ private fun Route.imageManageFileFetch(controller: ImageController) {
             if (imageFileDTO.bytes != null) {
                 call.respondBytes(imageFileDTO.bytes, ContentType.Image.Any)
             } else {
+                val client by inject<HttpClient>()
                 call.respondBytes(client.get(imageFileDTO.url!!).bodyAsBytes(), ContentType.Image.Any)
             }
         }
@@ -498,6 +503,7 @@ private fun Route.imageManageThumbnailFileFetch(controller: ImageController) {
             if (imageFileDTO.bytes != null) {
                 call.respondBytes(imageFileDTO.bytes, ContentType.Image.Any)
             } else {
+                val client by inject<HttpClient>()
                 call.respondBytes(client.get(imageFileDTO.url!!).bodyAsBytes(), ContentType.Image.Any)
             }
         }

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/controller/PermissionController.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/controller/PermissionController.kt
@@ -9,13 +9,14 @@ import io.sakurasou.hoshizora.controller.vo.CommonResponse
 import io.sakurasou.hoshizora.controller.vo.PermissionVO
 import io.sakurasou.hoshizora.extension.success
 import io.sakurasou.hoshizora.plugins.AuthorizationPlugin
+import io.sakurasou.hoshizora.service.permission.PermissionService
 
 /**
  * @author Shiina Kin
  * 2024/12/2 17:54
  */
 
-fun Route.permissionRoutes(permissionService: io.sakurasou.hoshizora.service.permission.PermissionService) {
+fun Route.permissionRoutes(permissionService: PermissionService) {
     val controller = PermissionController(permissionService)
     route("permission", {
         protected = true
@@ -45,7 +46,7 @@ private fun Route.fetchAllPermissions(controller: PermissionController) {
 }
 
 class PermissionController(
-    private val permissionService: io.sakurasou.hoshizora.service.permission.PermissionService,
+    private val permissionService: PermissionService,
 ) {
     suspend fun handleFetchAllPermissions(): List<PermissionVO> {
         val allPermissions = permissionService.fetchAllPermissions()

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/controller/PersonalAccessTokenController.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/controller/PersonalAccessTokenController.kt
@@ -25,6 +25,7 @@ import io.sakurasou.hoshizora.extension.pageRequest
 import io.sakurasou.hoshizora.extension.pageRequestSpec
 import io.sakurasou.hoshizora.extension.success
 import io.sakurasou.hoshizora.plugins.AuthorizationPlugin
+import io.sakurasou.hoshizora.service.personalAccessToken.PersonalAccessTokenService
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Clock
@@ -34,9 +35,7 @@ import kotlin.time.Clock
  * 2024/11/16 05:38
  */
 
-fun Route.personalAccessTokenRoute(
-    personalAccessTokenService: io.sakurasou.hoshizora.service.personalAccessToken.PersonalAccessTokenService,
-) {
+fun Route.personalAccessTokenRoute(personalAccessTokenService: PersonalAccessTokenService) {
     val controller = PersonalAccessTokenController(personalAccessTokenService)
     route("personal-access-token", {
         protected = true
@@ -194,7 +193,7 @@ private fun Route.patPage(controller: PersonalAccessTokenController) {
 private fun ApplicationCall.patId() = parameters["patId"]?.toLongOrNull() ?: throw WrongParameterException("Invalid patId")
 
 class PersonalAccessTokenController(
-    private val personalAccessTokenService: io.sakurasou.hoshizora.service.personalAccessToken.PersonalAccessTokenService,
+    private val personalAccessTokenService: PersonalAccessTokenService,
 ) {
     suspend fun handleInsert(
         userId: Long,

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/controller/RoleController.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/controller/RoleController.kt
@@ -26,13 +26,14 @@ import io.sakurasou.hoshizora.extension.pageRequest
 import io.sakurasou.hoshizora.extension.pageRequestSpec
 import io.sakurasou.hoshizora.extension.success
 import io.sakurasou.hoshizora.plugins.AuthorizationPlugin
+import io.sakurasou.hoshizora.service.role.RoleService
 
 /**
  * @author Shiina Kin
  * 2024/9/9 08:53
  */
 
-fun Route.roleRoute(roleService: io.sakurasou.hoshizora.service.role.RoleService) {
+fun Route.roleRoute(roleService: RoleService) {
     val controller = RoleController(roleService)
     route("role", {
         protected = true
@@ -225,7 +226,7 @@ private fun Route.pageRoles(controller: RoleController) {
 }
 
 class RoleController(
-    private val roleService: io.sakurasou.hoshizora.service.role.RoleService,
+    private val roleService: RoleService,
 ) {
     suspend fun handleInsertRole(insertRequest: RoleInsertRequest) {
         roleService.saveRole(insertRequest)

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/controller/StrategyController.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/controller/StrategyController.kt
@@ -31,13 +31,14 @@ import io.sakurasou.hoshizora.model.strategy.S3Strategy
 import io.sakurasou.hoshizora.model.strategy.StrategyConfig
 import io.sakurasou.hoshizora.model.strategy.WebDavStrategy
 import io.sakurasou.hoshizora.plugins.AuthorizationPlugin
+import io.sakurasou.hoshizora.service.strategy.StrategyService
 import io.swagger.v3.oas.models.media.Schema
 
 /**
  * @author Shiina Kin
  * 2024/9/9 08:59
  */
-fun Route.strategyRoute(strategyService: io.sakurasou.hoshizora.service.strategy.StrategyService) {
+fun Route.strategyRoute(strategyService: StrategyService) {
     val controller = StrategyController(strategyService)
     route("strategy", {
         protected = true
@@ -564,7 +565,7 @@ private fun Route.pageStrategies(controller: StrategyController) {
 }
 
 class StrategyController(
-    private val strategyService: io.sakurasou.hoshizora.service.strategy.StrategyService,
+    private val strategyService: StrategyService,
 ) {
     suspend fun handleInsertStrategy(request: StrategyInsertRequest) {
         strategyService.saveStrategy(request)

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/controller/SystemController.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/controller/SystemController.kt
@@ -10,13 +10,14 @@ import io.sakurasou.hoshizora.controller.vo.SystemOverviewVO
 import io.sakurasou.hoshizora.controller.vo.SystemStatisticsVO
 import io.sakurasou.hoshizora.extension.success
 import io.sakurasou.hoshizora.plugins.AuthorizationPlugin
+import io.sakurasou.hoshizora.service.system.SystemService
 
 /**
  * @author Shiina Kin
  * 2024/11/18 20:12
  */
 
-fun Route.systemRoute(systemService: io.sakurasou.hoshizora.service.system.SystemService) {
+fun Route.systemRoute(systemService: SystemService) {
     val controller = SystemController(systemService)
     route("system", {
         tags("system")
@@ -65,7 +66,7 @@ private fun Route.systemOverview(controller: SystemController) {
 }
 
 class SystemController(
-    private val systemService: io.sakurasou.hoshizora.service.system.SystemService,
+    private val systemService: SystemService,
 ) {
     suspend fun handleSystemStatistics(): SystemStatisticsVO {
         val systemStatisticsVO = systemService.fetchSystemStatistics()

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/controller/UserController.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/controller/UserController.kt
@@ -29,15 +29,20 @@ import io.sakurasou.hoshizora.controller.vo.PageResult
 import io.sakurasou.hoshizora.controller.vo.UserPageVO
 import io.sakurasou.hoshizora.controller.vo.UserVO
 import io.sakurasou.hoshizora.exception.controller.param.WrongParameterException
-import io.sakurasou.hoshizora.extension.*
+import io.sakurasou.hoshizora.extension.getPrincipal
+import io.sakurasou.hoshizora.extension.id
+import io.sakurasou.hoshizora.extension.pageRequest
+import io.sakurasou.hoshizora.extension.pageRequestSpec
+import io.sakurasou.hoshizora.extension.success
 import io.sakurasou.hoshizora.plugins.AuthorizationPlugin
+import io.sakurasou.hoshizora.service.user.UserService
 
 /**
  * @author ShiinaKin
  * 2024/9/5 15:35
  */
 
-fun Route.userRoute(userService: io.sakurasou.hoshizora.service.user.UserService) {
+fun Route.userRoute(userService: UserService) {
     val controller = UserController(userService)
     route("user", {
         protected = true
@@ -382,7 +387,7 @@ private fun Route.banAndUnban(controller: UserController) {
 }
 
 class UserController(
-    private val userService: io.sakurasou.hoshizora.service.user.UserService,
+    private val userService: UserService,
 ) {
     suspend fun handleSelfPatch(
         id: Long,

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/di/DI.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/di/DI.kt
@@ -1,7 +1,5 @@
 package io.sakurasou.hoshizora.di
 
-import io.ktor.util.collections.ConcurrentMap
-import kotlinx.coroutines.sync.Mutex
 import kotlin.reflect.KClass
 
 /**

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/di/DI.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/di/DI.kt
@@ -1,0 +1,68 @@
+package io.sakurasou.hoshizora.di
+
+import io.ktor.util.collections.ConcurrentMap
+import kotlinx.coroutines.sync.Mutex
+import kotlin.reflect.KClass
+
+/**
+ * @author Shiina Kin
+ * 2026/4/2 22:46
+ */
+
+object DIManager {
+    private val diInstance = DI()
+
+    fun getDIInstance() = diInstance
+}
+
+interface DIRegistryScope {
+    fun <T : Any> register(
+        clazz: KClass<T>,
+        factory: (DIGetScope) -> T,
+    )
+}
+
+interface DIGetScope {
+    fun <T : Any> get(clazz: KClass<T>): T
+}
+
+class DI :
+    DIRegistryScope,
+    DIGetScope {
+    private val factoryMap: MutableMap<KClass<*>, (DIGetScope) -> Any> = mutableMapOf()
+    private val instanceMap: MutableMap<KClass<*>, Any> = mutableMapOf()
+
+    private val mutex = Any()
+
+    override fun <T : Any> register(
+        clazz: KClass<T>,
+        factory: (DIGetScope) -> T,
+    ) {
+        synchronized(mutex) {
+            // factoryMap[clazz] = factory
+            // if (instanceMap.contains(clazz)) instanceMap[clazz] = factory(this)
+            if (factoryMap.contains(clazz)) throw RuntimeException("Already registered for ${clazz.qualifiedName}")
+            factoryMap[clazz] = factory
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Any> get(clazz: KClass<T>): T {
+        synchronized(mutex) {
+            return instanceMap.getOrPut(clazz) {
+                val factory =
+                    factoryMap[clazz]
+                        ?: throw RuntimeException("No factory found for class: ${clazz.qualifiedName}")
+                factory(this)
+            } as T
+        }
+    }
+}
+
+inline fun diOperation(block: DI.() -> Unit) = block(DIManager.getDIInstance())
+
+inline fun <reified T : Any> DIRegistryScope.register(noinline factory: (DIGetScope) -> T) = register(T::class, factory)
+
+inline fun <reified T : Any> DIGetScope.get(): T = get(T::class)
+
+inline fun <reified T : Any> inject() = lazy { DIManager.getDIInstance().get<T>() }

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/di/InstanceCenter.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/di/InstanceCenter.kt
@@ -53,128 +53,61 @@ import io.sakurasou.hoshizora.service.system.SystemService
 import io.sakurasou.hoshizora.service.system.SystemServiceImpl
 import io.sakurasou.hoshizora.service.user.UserService
 import io.sakurasou.hoshizora.service.user.UserServiceImpl
-import org.jetbrains.exposed.v1.jdbc.Database
 
 /**
  * @author Shiina Kin
  * 2024/9/12 11:48
  */
 object InstanceCenter {
-    lateinit var client: HttpClient
-
-    lateinit var database: Database
-
-    lateinit var userDao: UserDao
-    lateinit var imageDao: ImageDao
-    lateinit var albumDao: AlbumDao
-    lateinit var strategyDao: StrategyDao
-    lateinit var settingDao: SettingDao
-    lateinit var groupDao: GroupDao
-    lateinit var personalAccessTokenDao: PersonalAccessTokenDao
-    lateinit var roleDao: RoleDao
-    lateinit var permissionDao: PermissionDao
-    lateinit var relationDao: RelationDao
-    lateinit var taskDao: TaskDao
-
-    lateinit var authService: AuthService
-    lateinit var userService: UserService
-    lateinit var groupService: GroupService
-    lateinit var imageService: ImageService
-    lateinit var albumService: AlbumService
-
-    lateinit var strategyService: StrategyService
-    lateinit var settingService: SettingService
-    lateinit var commonService: CommonService
-    lateinit var roleService: RoleService
-    lateinit var permissionService: PermissionService
-    lateinit var personalAccessTokenService: PersonalAccessTokenService
-
-    lateinit var systemService: SystemService
     lateinit var systemStatus: SystemStatus
+
+    fun init() {
+        diOperation {
+            register<UserDao> { UserDaoImpl() }
+            register<ImageDao> { ImageDaoImpl() }
+            register<AlbumDao> { AlbumDaoImpl() }
+            register<StrategyDao> { StrategyDaoImpl() }
+            register<SettingDao> { SettingDaoImpl() }
+            register<GroupDao> { GroupDaoImpl() }
+            register<PersonalAccessTokenDao> { PersonalAccessTokenDaoImpl() }
+            register<RoleDao> { RoleDaoImpl() }
+            register<PermissionDao> { PermissionDaoImpl() }
+            register<RelationDao> { RelationDaoImpl() }
+            register<TaskDao> { TaskDaoImpl() }
+            register<AuthService> { AuthServiceImpl(get(), get()) }
+            register<UserService> { UserServiceImpl(get(), get(), get(), get(), get()) }
+            register<GroupService> { GroupServiceImpl(get(), get(), get(), get()) }
+            register<ImageService> { ImageServiceImpl(get(), get(), get(), get(), get(), get()) }
+            register<AlbumService> { AlbumServiceImpl(get(), get(), get()) }
+            register<StrategyService> { StrategyServiceImpl(get(), get()) }
+            register<SettingService> { SettingServiceImpl(get()) }
+            register<CommonService> { CommonServiceImpl(get(), get(), get(), get(), get()) }
+            register<RoleService> { RoleServiceImpl(get(), get(), get()) }
+            register<PermissionService> { PermissionServiceImpl(get()) }
+            register<PersonalAccessTokenService> { PersonalAccessTokenServiceImpl(get(), get(), get(), get()) }
+            register<SystemService> { SystemServiceImpl(get(), get(), get()) }
+        }
+    }
 
     fun initClient(
         timeout: Long = 30000,
         proxyAddress: String,
     ) {
-        client =
-            HttpClient(CIO) {
-                install(HttpTimeout) { requestTimeoutMillis = timeout }
-                install(Logging)
-                if (proxyAddress != "disabled") {
-                    engine { proxy = ProxyBuilder.http(proxyAddress) }
+        diOperation {
+            register {
+                HttpClient(CIO) {
+                    install(HttpTimeout) { requestTimeoutMillis = timeout }
+                    install(Logging)
+                    if (proxyAddress != "disabled") {
+                        engine { proxy = ProxyBuilder.http(proxyAddress) }
+                    }
                 }
             }
-    }
-
-    fun initDao() {
-        userDao = UserDaoImpl()
-        imageDao = ImageDaoImpl()
-        albumDao = AlbumDaoImpl()
-        strategyDao = StrategyDaoImpl()
-        settingDao = SettingDaoImpl()
-        groupDao = GroupDaoImpl()
-        personalAccessTokenDao = PersonalAccessTokenDaoImpl()
-        roleDao = RoleDaoImpl()
-        permissionDao = PermissionDaoImpl()
-        relationDao = RelationDaoImpl()
-        taskDao = TaskDaoImpl()
-    }
-
-    fun initService() {
-        settingService = SettingServiceImpl(settingDao)
-        permissionService = PermissionServiceImpl(permissionDao)
-
-        authService = AuthServiceImpl(userDao, relationDao)
-        strategyService = StrategyServiceImpl(strategyDao, groupDao)
-
-        albumService = AlbumServiceImpl(userDao, albumDao, imageDao)
-        roleService = RoleServiceImpl(roleDao, permissionDao, relationDao)
-        systemService = SystemServiceImpl(imageDao, albumDao, userDao)
-
-        groupService =
-            GroupServiceImpl(
-                groupDao,
-                userDao,
-                strategyDao,
-                relationDao,
-            )
-        personalAccessTokenService =
-            PersonalAccessTokenServiceImpl(
-                personalAccessTokenDao,
-                userDao,
-                groupDao,
-                relationDao,
-            )
-
-        userService =
-            UserServiceImpl(
-                userDao,
-                groupDao,
-                albumDao,
-                imageDao,
-                settingService,
-            )
-        commonService =
-            CommonServiceImpl(
-                userDao,
-                albumDao,
-                strategyDao,
-                imageDao,
-                settingService,
-            )
-
-        imageService =
-            ImageServiceImpl(
-                imageDao,
-                albumDao,
-                userDao,
-                groupDao,
-                strategyDao,
-                settingService,
-            )
+        }
     }
 
     suspend fun initSystemStatus() {
+        val settingService: SettingService by inject()
         systemStatus = settingService.getSystemStatus()
     }
 }

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/executor/Executor.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/executor/Executor.kt
@@ -1,6 +1,7 @@
 package io.sakurasou.hoshizora.executor
 
-import io.sakurasou.hoshizora.di.InstanceCenter
+import io.sakurasou.hoshizora.di.inject
+import io.sakurasou.hoshizora.model.dao.task.TaskDao
 import io.sakurasou.hoshizora.model.entity.Task
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
@@ -11,7 +12,7 @@ import kotlinx.coroutines.channels.Channel
  * 2026/3/31 20:48
  */
 abstract class Executor {
-    protected val taskDao = InstanceCenter.taskDao
+    protected val taskDao by inject<TaskDao>()
 
     companion object {
         const val MAX_WORKER_SIZE = 32

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/listener/TaskListener.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/listener/TaskListener.kt
@@ -1,9 +1,10 @@
 package io.sakurasou.hoshizora.listener
 
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.sakurasou.hoshizora.di.InstanceCenter
+import io.sakurasou.hoshizora.di.inject
 import io.sakurasou.hoshizora.executor.ImageExecutor
 import io.sakurasou.hoshizora.model.DatabaseSingleton.dbQuery
+import io.sakurasou.hoshizora.model.dao.task.TaskDao
 import io.sakurasou.hoshizora.model.task.ImageTask
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
@@ -11,6 +12,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlin.getValue
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
@@ -20,7 +22,7 @@ import kotlin.time.Duration.Companion.seconds
  */
 object TaskListener {
     private val logger = KotlinLogging.logger {}
-    private val taskDao = InstanceCenter.taskDao
+    private val taskDao by inject<TaskDao>()
 
     private val taskListenerScope =
         CoroutineScope(

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/model/DatabaseSingleton.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/model/DatabaseSingleton.kt
@@ -2,7 +2,10 @@ package io.sakurasou.hoshizora.model
 
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
-import io.sakurasou.hoshizora.di.InstanceCenter
+import io.sakurasou.hoshizora.di.DIManager
+import io.sakurasou.hoshizora.di.diOperation
+import io.sakurasou.hoshizora.di.get
+import io.sakurasou.hoshizora.di.register
 import io.sakurasou.hoshizora.model.common.DatabaseInit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -33,13 +36,15 @@ object DatabaseSingleton {
             }
         val dataSource = HikariDataSource(hikariConfig)
 
-        InstanceCenter.database = Database.connect(dataSource)
+        diOperation {
+            register { Database.connect(dataSource) }
+        }
 
         DatabaseInit.init(version)
     }
 
     suspend fun <T> dbQuery(block: suspend () -> T): T =
-        suspendTransaction(InstanceCenter.database) {
+        suspendTransaction(DIManager.getDIInstance().get()) {
             withContext(Dispatchers.IO) {
                 block()
             }

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/model/common/DatabaseInit.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/model/common/DatabaseInit.kt
@@ -5,18 +5,25 @@ package io.sakurasou.hoshizora.model.common
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.sakurasou.hoshizora.constant.*
 import io.sakurasou.hoshizora.di.InstanceCenter
+import io.sakurasou.hoshizora.di.inject
 import io.sakurasou.hoshizora.model.DatabaseSingleton.dbQuery
 import io.sakurasou.hoshizora.model.dao.album.Albums
+import io.sakurasou.hoshizora.model.dao.group.GroupDao
 import io.sakurasou.hoshizora.model.dao.group.Groups
 import io.sakurasou.hoshizora.model.dao.image.Images
+import io.sakurasou.hoshizora.model.dao.permission.PermissionDao
 import io.sakurasou.hoshizora.model.dao.permission.Permissions
 import io.sakurasou.hoshizora.model.dao.personalAccessToken.PersonalAccessTokens
 import io.sakurasou.hoshizora.model.dao.relation.GroupRoles
 import io.sakurasou.hoshizora.model.dao.relation.PersonalAccessTokenPermissions
+import io.sakurasou.hoshizora.model.dao.relation.RelationDao
 import io.sakurasou.hoshizora.model.dao.relation.RolePermissions
+import io.sakurasou.hoshizora.model.dao.role.RoleDao
 import io.sakurasou.hoshizora.model.dao.role.Roles
+import io.sakurasou.hoshizora.model.dao.setting.SettingDao
 import io.sakurasou.hoshizora.model.dao.setting.Settings
 import io.sakurasou.hoshizora.model.dao.strategy.Strategies
+import io.sakurasou.hoshizora.model.dao.strategy.StrategyDao
 import io.sakurasou.hoshizora.model.dao.task.Tasks
 import io.sakurasou.hoshizora.model.dao.user.Users
 import io.sakurasou.hoshizora.model.dto.GroupInsertDTO
@@ -96,7 +103,8 @@ object DatabaseInit {
             ).flatten()
                 .map { PermissionInsertDTO(it, null) }
 
-        InstanceCenter.permissionDao.batchSavePermission(allPermissions)
+        val permissionDao by inject<PermissionDao>()
+        permissionDao.batchSavePermission(allPermissions)
 
         logger.info { "permission init success" }
     }
@@ -118,8 +126,9 @@ object DatabaseInit {
                 description = null,
                 createTime = Clock.System.now().toLocalDateTime(TimeZone.UTC),
             )
-        InstanceCenter.roleDao.saveRole(adminRoleInsertDTO)
-        InstanceCenter.roleDao.saveRole(userRoleInsertDTO)
+        val roleDao by inject<RoleDao>()
+        roleDao.saveRole(adminRoleInsertDTO)
+        roleDao.saveRole(userRoleInsertDTO)
 
         logger.info { "role init success" }
     }
@@ -135,7 +144,8 @@ object DatabaseInit {
                 createTime = now,
                 updateTime = now,
             )
-        InstanceCenter.strategyDao.saveStrategy(strategyInsertDTO)
+        val strategyDao by inject<StrategyDao>()
+        strategyDao.saveStrategy(strategyInsertDTO)
 
         logger.info { "strategy init success" }
     }
@@ -199,8 +209,10 @@ object DatabaseInit {
                 isSystemReserved = true,
                 createTime = Clock.System.now().toLocalDateTime(TimeZone.UTC),
             )
-        InstanceCenter.groupDao.saveGroup(adminGroup)
-        InstanceCenter.groupDao.saveGroup(userGroup)
+
+        val groupDao by inject<GroupDao>()
+        groupDao.saveGroup(adminGroup)
+        groupDao.saveGroup(userGroup)
 
         logger.info { "group init success" }
     }
@@ -235,16 +247,17 @@ object DatabaseInit {
                 PERSONAL_ACCESS_TOKEN_WRITE_SELF,
             )
 
-        InstanceCenter.relationDao.batchInsertRoleToPermissions(ROLE_ADMIN, adminPermissions)
-        InstanceCenter.relationDao.batchInsertRoleToPermissions(ROLE_USER, userPermissions)
+        val relationDao by inject<RelationDao>()
+        relationDao.batchInsertRoleToPermissions(ROLE_ADMIN, adminPermissions)
+        relationDao.batchInsertRoleToPermissions(ROLE_USER, userPermissions)
 
         logger.info { "role-permission relation init success" }
 
         // group-role
         val adminRoles = listOf(ROLE_ADMIN)
         val userRoles = listOf(ROLE_USER)
-        InstanceCenter.relationDao.batchInsertGroupToRoles(1, adminRoles)
-        InstanceCenter.relationDao.batchInsertGroupToRoles(2, userRoles)
+        relationDao.batchInsertGroupToRoles(1, adminRoles)
+        relationDao.batchInsertGroupToRoles(2, userRoles)
 
         logger.info { "group-role relation init success" }
     }
@@ -275,9 +288,10 @@ object DatabaseInit {
         val systemSettingInsertDTO = SettingInsertDTO(SETTING_SYSTEM, systemSettingConfig, now, now)
         val systemStatusInsertDTO = SettingInsertDTO(SETTING_STATUS, systemStatus, now, now)
 
-        InstanceCenter.settingDao.saveSetting(siteSettingInsertDTO)
-        InstanceCenter.settingDao.saveSetting(systemSettingInsertDTO)
-        InstanceCenter.settingDao.saveSetting(systemStatusInsertDTO)
+        val settingDao by inject<SettingDao>()
+        settingDao.saveSetting(siteSettingInsertDTO)
+        settingDao.saveSetting(systemSettingInsertDTO)
+        settingDao.saveSetting(systemStatusInsertDTO)
 
         logger.info { "setting init success" }
     }
@@ -302,7 +316,9 @@ object DatabaseInit {
                 )
             val now = Clock.System.now().toLocalDateTime(TimeZone.UTC)
             val updateDTO = SettingUpdateDTO(SETTING_STATUS, systemStatus, now)
-            InstanceCenter.settingDao.updateSettingByName(updateDTO)
+
+            val settingDao by inject<SettingDao>()
+            settingDao.updateSettingByName(updateDTO)
 
             // v0.3.0 breaking update
             if (oldVersion.isLowerThanOrEqualTo("0.3.0")) {

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/model/strategy/WebDavStrategy.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/model/strategy/WebDavStrategy.kt
@@ -1,6 +1,7 @@
 package io.sakurasou.hoshizora.model.strategy
 
 import io.github.smiley4.schemakenerator.core.annotations.Name
+import io.ktor.client.HttpClient
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.put
@@ -11,10 +12,11 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.http.headers
-import io.sakurasou.hoshizora.di.InstanceCenter.client
+import io.sakurasou.hoshizora.di.inject
 import io.sakurasou.hoshizora.exception.service.image.io.webdav.WebDavException
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.getValue
 import kotlin.io.encoding.Base64
 
 /**
@@ -49,6 +51,7 @@ data class WebDavStrategy(
         imageBytes: ByteArray,
         uploadPath: String,
     ) {
+        val client by inject<HttpClient>()
         client
             .put("$serverUrl/$uploadPath") {
                 addAuthHeader(this@WebDavStrategy)
@@ -60,6 +63,7 @@ data class WebDavStrategy(
     }
 
     override suspend fun delete(relativePath: String) {
+        val client by inject<HttpClient>()
         client
             .delete("$serverUrl/$relativePath") { addAuthHeader(this@WebDavStrategy) }
             .let {
@@ -69,8 +73,9 @@ data class WebDavStrategy(
             }
     }
 
-    override suspend fun fetch(relativePath: String): ByteArray =
-        client
+    override suspend fun fetch(relativePath: String): ByteArray {
+        val client by inject<HttpClient>()
+        return client
             .get("$serverUrl/$relativePath") { addAuthHeader(this@WebDavStrategy) }
             .let {
                 if (it.status != HttpStatusCode.OK || it.contentType() != ContentType.Image.Any) {
@@ -78,4 +83,5 @@ data class WebDavStrategy(
                 }
                 it.bodyAsBytes()
             }
+    }
 }

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/model/task/ImageTask.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/model/task/ImageTask.kt
@@ -1,3 +1,5 @@
+@file:Suppress("CanBeParameter")
+
 package io.sakurasou.hoshizora.model.task
 
 import io.github.oshai.kotlinlogging.KLogger

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/plugins/Authorization.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/plugins/Authorization.kt
@@ -6,11 +6,14 @@ import io.ktor.server.auth.AuthenticationChecked
 import io.ktor.server.auth.jwt.JWTPrincipal
 import io.ktor.server.auth.principal
 import io.ktor.util.AttributeKey
-import io.sakurasou.hoshizora.di.InstanceCenter
+import io.sakurasou.hoshizora.di.inject
 import io.sakurasou.hoshizora.exception.controller.access.PrincipalNotFoundException
 import io.sakurasou.hoshizora.exception.controller.status.UnauthorizedAccessException
 import io.sakurasou.hoshizora.extension.Principal
 import io.sakurasou.hoshizora.model.DatabaseSingleton.dbQuery
+import io.sakurasou.hoshizora.model.dao.personalAccessToken.PersonalAccessTokenDao
+import io.sakurasou.hoshizora.model.dao.relation.RelationDao
+import kotlin.getValue
 
 /**
  * @author Shiina Kin
@@ -40,13 +43,15 @@ val AuthorizationPlugin =
 
             if (patId != null) {
                 dbQuery {
-                    InstanceCenter.personalAccessTokenDao.findPATById(patId) ?: throw UnauthorizedAccessException()
+                    val personalAccessTokenDao by inject<PersonalAccessTokenDao>()
+                    personalAccessTokenDao.findPATById(patId) ?: throw UnauthorizedAccessException()
                 }
                 if (!permissions!!.contains(permission)) throw UnauthorizedAccessException()
             } else {
                 roles!!.forEach {
                     runCatching {
-                        val rolePermissions = dbQuery { InstanceCenter.relationDao.listPermissionByRole(it) }
+                        val relationDao by inject<RelationDao>()
+                        val rolePermissions = dbQuery { relationDao.listPermissionByRole(it) }
                         if (permission !in rolePermissions) throw UnauthorizedAccessException()
                     }.onFailure { exception ->
                         if (exception !is UnauthorizedAccessException) logger.trace { exception }

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/plugins/Routing.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/plugins/Routing.kt
@@ -19,7 +19,9 @@ import io.ktor.utils.io.readRemaining
 import io.sakurasou.hoshizora.config.apiRoute
 import io.sakurasou.hoshizora.config.exceptionHandler
 import io.sakurasou.hoshizora.controller.commonRoute
-import io.sakurasou.hoshizora.di.InstanceCenter.commonService
+import io.sakurasou.hoshizora.di.inject
+import io.sakurasou.hoshizora.service.common.CommonService
+import kotlin.getValue
 import kotlin.time.Duration.Companion.seconds
 
 fun Application.configureRouting() {
@@ -45,6 +47,7 @@ fun Application.configureRouting() {
     routing {
         apiRoute()
         route {
+            val commonService by inject<CommonService>()
             install(SiteInitCheckPlugin)
             commonRoute(commonService)
         }

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/util/ImageUtils.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/util/ImageUtils.kt
@@ -7,7 +7,6 @@ import io.sakurasou.hoshizora.model.strategy.LocalStrategy
 import io.sakurasou.hoshizora.model.strategy.S3Strategy
 import io.sakurasou.hoshizora.model.strategy.WebDavStrategy
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.im4java.core.ConvertCmd
 import org.im4java.core.IMOperation
@@ -52,9 +51,13 @@ object ImageUtils {
     ): ByteArray =
         withContext(Dispatchers.IO) {
             when (val strategyConfig = strategy.config) {
-                is S3Strategy -> throw RuntimeException("Not supported")
+                is S3Strategy -> {
+                    throw RuntimeException("Not supported")
+                }
 
-                is WebDavStrategy -> throw RuntimeException("Not supported")
+                is WebDavStrategy -> {
+                    throw RuntimeException("Not supported")
+                }
 
                 is LocalStrategy -> {
                     val parentFolderStr =
@@ -72,9 +75,13 @@ object ImageUtils {
     ): String {
         return withContext(Dispatchers.IO) {
             when (val strategyConfig = strategy.config) {
-                is LocalStrategy -> throw RuntimeException("Not supported")
+                is LocalStrategy -> {
+                    throw RuntimeException("Not supported")
+                }
 
-                is WebDavStrategy -> throw RuntimeException("Not supported")
+                is WebDavStrategy -> {
+                    throw RuntimeException("Not supported")
+                }
 
                 is S3Strategy -> {
                     val folder = if (isThumbnail) strategyConfig.thumbnailFolder else strategyConfig.uploadFolder
@@ -96,9 +103,13 @@ object ImageUtils {
     ): ByteArray =
         withContext(Dispatchers.IO) {
             when (val strategyConfig = strategy.config) {
-                is LocalStrategy -> throw RuntimeException("Not supported")
+                is LocalStrategy -> {
+                    throw RuntimeException("Not supported")
+                }
 
-                is S3Strategy -> throw RuntimeException("Not supported")
+                is S3Strategy -> {
+                    throw RuntimeException("Not supported")
+                }
 
                 is WebDavStrategy -> {
                     val folder = if (isThumbnail) strategyConfig.thumbnailFolder else strategyConfig.uploadFolder
@@ -170,7 +181,7 @@ object ImageUtils {
     /**
      * will block cur thread
      */
-    fun transformImageByWidth(
+    suspend fun transformImageByWidth(
         rawImage: BufferedImage,
         targetImageType: ImageType,
         newWidth: Int,
@@ -179,13 +190,13 @@ object ImageUtils {
         val originalWidth = rawImage.width
         val originalHeight = rawImage.height
         val newHeight = (originalHeight * newWidth) / originalWidth
-        return runBlocking { transformImage(rawImage, targetImageType, newWidth, newHeight, quality) }
+        return transformImage(rawImage, targetImageType, newWidth, newHeight, quality)
     }
 
     /**
      * will block cur thread
      */
-    fun transformImageByHeight(
+    suspend fun transformImageByHeight(
         rawImage: BufferedImage,
         targetImageType: ImageType,
         newHeight: Int,
@@ -194,7 +205,7 @@ object ImageUtils {
         val originalWidth = rawImage.width
         val originalHeight = rawImage.height
         val newWidth = (originalWidth * newHeight) / originalHeight
-        return runBlocking { transformImage(rawImage, targetImageType, newWidth, newHeight, quality) }
+        return transformImage(rawImage, targetImageType, newWidth, newHeight, quality)
     }
 
     class CustomOutputConsumer : OutputConsumer {


### PR DESCRIPTION
Register DAOs, services, the database, and `HttpClient` in the DI container and resolve them with `inject()` instead of shared globals. Pass injected services through routing and controllers, and make image transformation helpers suspend-safe by removing `runBlocking`.