### PR TITLE
refactor: Integrate ImageMagick by FFM API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,11 @@ WORKDIR /imagemagick
 RUN apt update && \
     apt install --no-install-recommends -y \
         git curl ca-certificates build-essential pkg-config libtool \
-        libtool libltdl-dev \
-        zlib1g-dev libbz2-dev liblzma-dev libzstd-dev \
+        libltdl-dev zlib1g-dev libbz2-dev liblzma-dev libzstd-dev \
         libfontconfig-dev libfreetype-dev libxml2-dev \
         libjpeg-dev libpng-dev libwebp-dev libtiff-dev \
-        libheif-dev libjbig-dev libjxl-dev \
-        liblcms2-dev liblqr-1-0-dev \
-        libopenexr-dev libopenjp2-7-dev libraw-dev \
+        libheif-dev libjbig-dev libjxl-dev liblcms2-dev \
+        liblqr-1-0-dev libopenexr-dev libopenjp2-7-dev libraw-dev \
         libdjvulibre-dev libpango1.0-dev libraqm-dev libwmf-dev libzip-dev
 RUN git clone --depth 1 --branch 7.1.2-18 https://github.com/ImageMagick/ImageMagick.git ImageMagick
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,36 @@
-FROM eclipse-temurin:25-jdk AS build
+FROM ubuntu:noble AS build-imagemagick
+
+WORKDIR /imagemagick
+
+RUN apt update && \
+    apt install --no-install-recommends -y \
+        git curl ca-certificates build-essential pkg-config libtool \
+        libtool libltdl-dev \
+        zlib1g-dev libbz2-dev liblzma-dev libzstd-dev \
+        libfontconfig-dev libfreetype-dev libxml2-dev \
+        libjpeg-dev libpng-dev libwebp-dev libtiff-dev \
+        libheif-dev libjbig-dev libjxl-dev \
+        liblcms2-dev liblqr-1-0-dev \
+        libopenexr-dev libopenjp2-7-dev libraw-dev \
+        libdjvulibre-dev libpango1.0-dev libraqm-dev libwmf-dev libzip-dev
+RUN git clone --depth 1 --branch 7.1.2-18 https://github.com/ImageMagick/ImageMagick.git ImageMagick
+
+RUN cd ImageMagick \
+          && ./configure --prefix=/opt/imagemagick --with-modules --disable-docs --without-x \
+          && make -j"$(nproc)" \
+          && make install \
+          && ldconfig /opt/imagemagick/lib
+
+FROM eclipse-temurin:25-jdk-noble AS build-app
+
+COPY --from=build-imagemagick /opt/imagemagick /opt/imagemagick
+RUN apt update && apt install --no-install-recommends -y \
+      libgomp1 liblcms2-2 libraqm0 liblqr-1-0 libxml2 libltdl7 libjbig0 libtiff6 \
+      libheif1 libwebpmux3 libwebpdemux2 libwebp7 libopenexr-3-1-30 libzip4 \
+      libwmflite-0.2-7 libdjvulibre21 libopenjp2-7 libjpeg-turbo8 libpangocairo-1.0-0 \
+      libpango-1.0-0 libglib2.0-0t64 libcairo2 libraw23t64 libjxl0.7 \
+   && rm -rf /var/lib/apt/lists/*
+RUN ldd /opt/imagemagick/lib/libMagickWand-7.Q16HDRI.so
 
 WORKDIR /hoshizora-pics
 
@@ -9,19 +41,30 @@ COPY app app
 COPY ui ui
 
 RUN chmod +x ./gradlew
+
+ENV CI=true
+ENV MAGICK_WAND_LIB_PATH=/opt/imagemagick/lib/libMagickWand-7.Q16HDRI.so
+
 RUN ./gradlew clean build
 
 FROM eclipse-temurin:25-jre-noble
 LABEL maintainer="ShiinaKin <shiina@sakurasou.io>"
 WORKDIR /hoshizora-pics
 
-# ImageMagic 6.x
-RUN apt update && apt install --no-install-recommends imagemagick -y
+COPY --from=build-imagemagick /opt/imagemagick /opt/imagemagick
+RUN apt update && apt install --no-install-recommends -y \
+      libgomp1 liblcms2-2 libraqm0 liblqr-1-0 libxml2 libltdl7 libjbig0 libtiff6 \
+      libheif1 libwebpmux3 libwebpdemux2 libwebp7 libopenexr-3-1-30 libzip4 \
+      libwmflite-0.2-7 libdjvulibre21 libopenjp2-7 libjpeg-turbo8 libpangocairo-1.0-0 \
+      libpango-1.0-0 libglib2.0-0t64 libcairo2 libraw23t64 libjxl0.7 \
+   && rm -rf /var/lib/apt/lists/*
+RUN ldd /opt/imagemagick/lib/libMagickWand-7.Q16HDRI.so
 
-COPY --from=build /hoshizora-pics/build/*.jar hoshizora-pics.jar
+COPY --from=build-app /hoshizora-pics/build/*.jar hoshizora-pics.jar
 
 VOLUME /hoshizora-pics/images
 
+ENV MAGICK_WAND_LIB_PATH=/opt/imagemagick/lib/libMagickWand-7.Q16HDRI.so
 ENV JVM_OPTS="-Xms256m -Xmx512m"
 
-ENTRYPOINT ["bash", "-c", "java $JVM_OPTS -jar hoshizora-pics.jar"]
+ENTRYPOINT ["bash", "-c", "java $JVM_OPTS --enable-native-access=ALL-UNNAMED -jar hoshizora-pics.jar"]

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,6 +45,12 @@ ktor {
     }
 }
 
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-Xcontext-parameters")
+    }
+}
+
 repositories {
     mavenCentral()
 }
@@ -123,6 +129,10 @@ dependencies {
 
 tasks.jar {
     enabled = false
+}
+
+tasks.withType<Test> {
+    jvmArgs("--enable-native-access=ALL-UNNAMED")
 }
 
 tasks.shadowJar {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,7 +30,7 @@ val commonsCodecVersion: String by project
 val mockkVersion: String by project
 
 plugins {
-    kotlin("jvm") version "2.3.20"
+    kotlin("jvm") version "2.4.0-Beta1"
     alias(libs.plugins.kotlinxSerialization)
     alias(libs.plugins.ktor)
 }
@@ -42,12 +42,6 @@ application {
 ktor {
     fatJar {
         archiveFileName = "hoshizora-pics-$version.jar"
-    }
-}
-
-kotlin {
-    compilerOptions {
-        freeCompilerArgs.add("-Xcontext-parameters")
     }
 }
 

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/Application.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/Application.kt
@@ -37,7 +37,7 @@ fun Application.swaggerModule() {
 }
 
 fun Application.mainModule() {
-    val imageMagickLibPath = environment.config.property("native.imagemagick").getString()
+    val imageMagickLibPath = environment.config.property("native.imagemagick.magickwand.lib").getString()
     if (!Path(imageMagickLibPath).exists()) throw Error("Image Magick Lib does not exist")
 
     val redisHost = environment.config.property("ktor.application.cache.redis.host").getString()

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/Application.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/Application.kt
@@ -38,7 +38,7 @@ fun Application.swaggerModule() {
 
 fun Application.mainModule() {
     val imageMagickLibPath = environment.config.property("native.imagemagick.magickwand.lib").getString()
-    if (!Path(imageMagickLibPath).exists()) throw Error("Image Magick Lib does not exist")
+    if (!Path(imageMagickLibPath).exists()) throw IllegalArgumentException("Image Magick Lib does not exist")
 
     val redisHost = environment.config.property("ktor.application.cache.redis.host").getString()
     val redisPort = environment.config.property("ktor.application.cache.redis.port").getString()

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/Application.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/Application.kt
@@ -24,7 +24,7 @@ import kotlin.io.path.exists
 fun main(args: Array<String>) {
     Runtime.getRuntime().addShutdownHook(
         Thread {
-            InstanceCenter.greasfullyShutdown()
+            InstanceCenter.gracefullyShutdown()
         },
     )
     EngineMain

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/Application.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/Application.kt
@@ -22,11 +22,6 @@ import kotlin.io.path.Path
 import kotlin.io.path.exists
 
 fun main(args: Array<String>) {
-    Runtime.getRuntime().addShutdownHook(
-        Thread {
-            InstanceCenter.gracefullyShutdown()
-        },
-    )
     EngineMain
         .main(args)
 }

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/Application.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/Application.kt
@@ -18,8 +18,15 @@ import io.sakurasou.hoshizora.plugins.configureSecurity
 import io.sakurasou.hoshizora.plugins.configureSerialization
 import io.sakurasou.hoshizora.plugins.configureSwagger
 import io.sakurasou.hoshizora.plugins.generateOpenApiJson
+import kotlin.io.path.Path
+import kotlin.io.path.exists
 
 fun main(args: Array<String>) {
+    Runtime.getRuntime().addShutdownHook(
+        Thread {
+            InstanceCenter.greasfullyShutdown()
+        },
+    )
     EngineMain
         .main(args)
 }
@@ -30,6 +37,9 @@ fun Application.swaggerModule() {
 }
 
 fun Application.mainModule() {
+    val imageMagickLibPath = environment.config.property("native.imagemagick").getString()
+    if (!Path(imageMagickLibPath).exists()) throw Error("Image Magick Lib does not exist")
+
     val redisHost = environment.config.property("ktor.application.cache.redis.host").getString()
     val redisPort = environment.config.property("ktor.application.cache.redis.port").getString()
 
@@ -40,7 +50,7 @@ fun Application.mainModule() {
             .toLong()
     val clientProxyAddress = environment.config.property("client.proxy.address").getString()
 
-    InstanceCenter.init()
+    InstanceCenter.init(imageMagickLibPath)
     InstanceCenter.initClient(clientTimeout, clientProxyAddress)
 
     configureDatabase()

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/di/InstanceCenter.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/di/InstanceCenter.kt
@@ -122,7 +122,7 @@ object InstanceCenter {
         systemStatus = settingService.getSystemStatus()
     }
 
-    fun greasfullyShutdown() {
+    fun gracefullyShutdown() {
         context(logger) {
             TaskListener.stopListening()
             ImageExecutor.shutdown()

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/di/InstanceCenter.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/di/InstanceCenter.kt
@@ -1,11 +1,14 @@
 package io.sakurasou.hoshizora.di
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.ProxyBuilder
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.engine.http
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.logging.Logging
+import io.sakurasou.hoshizora.executor.ImageExecutor
+import io.sakurasou.hoshizora.listener.TaskListener
 import io.sakurasou.hoshizora.model.dao.album.AlbumDao
 import io.sakurasou.hoshizora.model.dao.album.AlbumDaoImpl
 import io.sakurasou.hoshizora.model.dao.group.GroupDao
@@ -29,6 +32,7 @@ import io.sakurasou.hoshizora.model.dao.task.TaskDaoImpl
 import io.sakurasou.hoshizora.model.dao.user.UserDao
 import io.sakurasou.hoshizora.model.dao.user.UserDaoImpl
 import io.sakurasou.hoshizora.model.setting.SystemStatus
+import io.sakurasou.hoshizora.native.ImageOperation
 import io.sakurasou.hoshizora.service.album.AlbumService
 import io.sakurasou.hoshizora.service.album.AlbumServiceImpl
 import io.sakurasou.hoshizora.service.auth.AuthService
@@ -53,15 +57,20 @@ import io.sakurasou.hoshizora.service.system.SystemService
 import io.sakurasou.hoshizora.service.system.SystemServiceImpl
 import io.sakurasou.hoshizora.service.user.UserService
 import io.sakurasou.hoshizora.service.user.UserServiceImpl
+import java.lang.foreign.Arena
+import java.lang.foreign.Linker
+import java.lang.foreign.SymbolLookup
 
 /**
  * @author Shiina Kin
  * 2024/9/12 11:48
  */
 object InstanceCenter {
+    private val logger = KotlinLogging.logger { }
+
     lateinit var systemStatus: SystemStatus
 
-    fun init() {
+    fun init(imageMagickLibPath: String) {
         diOperation {
             register<UserDao> { UserDaoImpl() }
             register<ImageDao> { ImageDaoImpl() }
@@ -86,6 +95,8 @@ object InstanceCenter {
             register<PermissionService> { PermissionServiceImpl(get()) }
             register<PersonalAccessTokenService> { PersonalAccessTokenServiceImpl(get(), get(), get(), get()) }
             register<SystemService> { SystemServiceImpl(get(), get(), get()) }
+            register { Linker.nativeLinker() }
+            register { SymbolLookup.libraryLookup(imageMagickLibPath, Arena.global()) }
         }
     }
 
@@ -109,5 +120,13 @@ object InstanceCenter {
     suspend fun initSystemStatus() {
         val settingService: SettingService by inject()
         systemStatus = settingService.getSystemStatus()
+    }
+
+    fun greasfullyShutdown() {
+        context(logger) {
+            TaskListener.stopListening()
+            ImageExecutor.shutdown()
+            ImageOperation.terminus()
+        }
     }
 }

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/exception/native/ImageOperationException.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/exception/native/ImageOperationException.kt
@@ -1,0 +1,14 @@
+package io.sakurasou.hoshizora.exception.native
+
+import io.sakurasou.hoshizora.exception.ServiceException
+
+/**
+ * @author Shiina Kin
+ * 2026/4/9 22:00
+ */
+class ImageOperationException(
+    override val message: String,
+) : ServiceException() {
+    override val code: Int
+        get() = 9001
+}

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/listener/TaskListener.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/listener/TaskListener.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.getValue
@@ -68,5 +69,9 @@ object TaskListener {
                 delay(30.seconds)
             }
         }
+    }
+
+    fun stopListening() {
+        taskListenerScope.cancel()
     }
 }

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/model/task/ImageTask.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/model/task/ImageTask.kt
@@ -18,7 +18,7 @@ import kotlinx.serialization.Serializable
  */
 
 private const val THUMBNAIL_HEIGHT = 256L
-private const val THUMBNAIL_QUALITY = 0.9
+private const val THUMBNAIL_QUALITY = 100
 
 @Serializable
 sealed class ImageTask(

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/model/task/ImageTask.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/model/task/ImageTask.kt
@@ -11,14 +11,13 @@ import io.sakurasou.hoshizora.model.task.ImageTask.Operation.DELETE_THUMBNAIL
 import io.sakurasou.hoshizora.model.task.ImageTask.Operation.PERSIST_THUMBNAIL
 import io.sakurasou.hoshizora.util.ImageUtils
 import kotlinx.serialization.Serializable
-import javax.imageio.ImageIO
 
 /**
  * @author Shiina Kin
  * 2024/12/18 18:38
  */
 
-private const val THUMBNAIL_HEIGHT = 256
+private const val THUMBNAIL_HEIGHT = 256L
 private const val THUMBNAIL_QUALITY = 0.9
 
 @Serializable
@@ -26,8 +25,7 @@ sealed class ImageTask(
     private val opImageID: Long,
     private val operationEnum: Operation,
 ) : Task(TaskType.IMAGE, opImageID.toString(), operationEnum.toString()) {
-    protected val logger: KLogger
-        get() = KotlinLogging.logger {}
+    abstract val logger: KLogger
 
     enum class Operation {
         PERSIST_THUMBNAIL,
@@ -49,6 +47,9 @@ class PersistImageThumbnailTask(
     private val strategy: Strategy,
     private val relativePath: String,
 ) : ImageTask(imageID, PERSIST_THUMBNAIL) {
+    override val logger: KLogger
+        get() = KotlinLogging.logger {}
+
     override suspend fun execute() {
         val fileName = relativePath.substringAfterLast('/')
         val rawImagePath = "${strategy.config.uploadFolder}/$relativePath"
@@ -56,10 +57,18 @@ class PersistImageThumbnailTask(
             .fetch(rawImagePath)
             .inputStream()
             .use { rawImageInputStream ->
-                val rawImage = ImageIO.read(rawImageInputStream)
+                val rawImageBytes = rawImageInputStream.readBytes()
                 val imageType = ImageType.valueOf(fileName.substringAfterLast('.').uppercase())
+
                 val thumbnailBytes =
-                    ImageUtils.transformImageByHeight(rawImage, imageType, THUMBNAIL_HEIGHT, THUMBNAIL_QUALITY)
+                    context(logger) {
+                        ImageUtils.transformImageByHeight(
+                            rawImageBytes = rawImageBytes,
+                            targetImageType = imageType,
+                            newHeight = THUMBNAIL_HEIGHT,
+                            quality = THUMBNAIL_QUALITY,
+                        )
+                    }
                 ImageUtils.saveThumbnail(strategy, thumbnailBytes, relativePath)
             }
         logger.debug { "persist thumbnail $fileName in strategy(id ${strategy.id})" }
@@ -72,6 +81,9 @@ class DeleteImageTask(
     private val strategy: Strategy,
     private val relativePath: String,
 ) : ImageTask(imageID, DELETE_IMAGE) {
+    override val logger: KLogger
+        get() = KotlinLogging.logger {}
+
     override suspend fun execute() {
         val filePath = "${strategy.config.uploadFolder}/$relativePath"
         strategy.config.delete(filePath)
@@ -86,6 +98,9 @@ class DeleteThumbnailTask(
     private val strategy: Strategy,
     private val relativePath: String,
 ) : ImageTask(imageID, DELETE_THUMBNAIL) {
+    override val logger: KLogger
+        get() = KotlinLogging.logger {}
+
     override suspend fun execute() {
         val filePath = "${strategy.config.uploadFolder}/$relativePath"
         strategy.config.delete(filePath)

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/native/ImageOperation.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/native/ImageOperation.kt
@@ -20,6 +20,7 @@ import java.lang.invoke.MethodHandle
 object ImageOperation {
     private const val MAGICK_BOOLEAN_TRUE = 1
     private const val MAX_EXCEPTION_MESSAGE_SIZE = 4096L
+    private const val MAX_IMAGE_FORMAT_SIZE = 64L
     private val methodHandleDict = mutableMapOf<String, MethodHandle>()
 
     init {
@@ -68,6 +69,21 @@ object ImageOperation {
             linker.downcallHandle(
                 imageMagickLib.findOrThrow("MagickGetImageBlob"),
                 FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
+            )
+        methodHandleDict["MagickGetImageFormat"] =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickGetImageFormat"),
+                FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS),
+            )
+        methodHandleDict["MagickGetImageWidth"] =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickGetImageWidth"),
+                FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS),
+            )
+        methodHandleDict["MagickGetImageHeight"] =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickGetImageHeight"),
+                FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS),
             )
         methodHandleDict["MagickWriteImage"] =
             linker.downcallHandle(
@@ -205,6 +221,45 @@ object ImageOperation {
             blobPtr = imageBlobPtr,
             bytes = imageBytes,
         )
+    }
+
+    context(logger: KLogger)
+    fun getImageFormat(magickWandPtr: MemorySegment): String {
+        val magickGetImageFormatCall = methodHandleDict.getValue("MagickGetImageFormat")
+        val imageFormatPtr = magickGetImageFormatCall.invoke(magickWandPtr) as MemorySegment
+        if (imageFormatPtr == MemorySegment.NULL) {
+            failOperation("MagickGetImageFormat", magickWandPtr)
+        }
+        val imageFormat =
+            try {
+                imageFormatPtr.reinterpret(MAX_IMAGE_FORMAT_SIZE).getString(0)
+            } finally {
+                relinquishMemory(imageFormatPtr)
+            }
+        logger.debug {
+            "Fetched image format=$imageFormat from wand pointer=${magickWandPtr.pointerString()}"
+        }
+        return imageFormat
+    }
+
+    context(logger: KLogger)
+    fun getImageWidth(magickWandPtr: MemorySegment): Long {
+        val magickGetImageWidthCall = methodHandleDict.getValue("MagickGetImageWidth")
+        val width = magickGetImageWidthCall.invoke(magickWandPtr) as Long
+        logger.debug {
+            "Fetched image width=$width from wand pointer=${magickWandPtr.pointerString()}"
+        }
+        return width
+    }
+
+    context(logger: KLogger)
+    fun getImageHeight(magickWandPtr: MemorySegment): Long {
+        val magickGetImageHeightCall = methodHandleDict.getValue("MagickGetImageHeight")
+        val height = magickGetImageHeightCall.invoke(magickWandPtr) as Long
+        logger.debug {
+            "Fetched image height=$height from wand pointer=${magickWandPtr.pointerString()}"
+        }
+        return height
     }
 
     context(logger: KLogger, arena: Arena)

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/native/ImageOperation.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/native/ImageOperation.kt
@@ -1,0 +1,444 @@
+package io.sakurasou.hoshizora.native
+
+import io.github.oshai.kotlinlogging.KLogger
+import io.sakurasou.hoshizora.exception.native.ImageOperationException
+import io.sakurasou.hoshizora.model.group.ImageType
+import java.lang.foreign.Arena
+import java.lang.foreign.FunctionDescriptor
+import java.lang.foreign.Linker
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.SymbolLookup
+import java.lang.foreign.ValueLayout
+
+/**
+ * @author Shiina Kin
+ * 2026/4/9 19:36
+ */
+object ImageOperation {
+    private const val MAGICK_BOOLEAN_TRUE = 1
+    private const val MAX_EXCEPTION_MESSAGE_SIZE = 4096L
+
+    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    fun genesis() {
+        val magickWandGenesisCall =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickWandGenesis"),
+                FunctionDescriptor.ofVoid(),
+            )
+        logger.info { "Initializing ImageMagick runtime" }
+        magickWandGenesisCall.invoke()
+        logger.info { "ImageMagick initialized" }
+    }
+
+    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    fun terminus() {
+        val magickWandTerminusCall =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickWandTerminus"),
+                FunctionDescriptor.ofVoid(),
+            )
+        logger.info { "Terminating ImageMagick runtime" }
+        magickWandTerminusCall.invoke()
+        logger.info { "ImageMagick terminated" }
+    }
+
+    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    fun newMagickWand(): MemorySegment {
+        val newMagickWandCall =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("NewMagickWand"),
+                FunctionDescriptor.of(ValueLayout.ADDRESS),
+            )
+        val magickWandPtr = newMagickWandCall.invoke() as MemorySegment
+        if (magickWandPtr == MemorySegment.NULL) {
+            logger.error { "Failed to create MagickWand: native call returned NULL" }
+            throw ImageOperationException("Failed to create MagickWand: native call returned NULL")
+        }
+        logger.debug { "Created MagickWand pointer=${magickWandPtr.pointerString()}" }
+        return magickWandPtr
+    }
+
+    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    fun destroyMagickWand(magickWandPtr: MemorySegment) {
+        val destroyMagickWandCall =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("DestroyMagickWand"),
+                FunctionDescriptor.ofVoid(ValueLayout.ADDRESS),
+            )
+        destroyMagickWandCall.invoke(magickWandPtr)
+        logger.debug { "Destroyed MagickWand pointer=${magickWandPtr.pointerString()}" }
+    }
+
+    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    fun relinquishMemory(imageBlobPtr: MemorySegment) {
+        val relinquishMemoryCall =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickRelinquishMemory"),
+                FunctionDescriptor.ofVoid(ValueLayout.ADDRESS),
+            )
+        relinquishMemoryCall.invoke(imageBlobPtr)
+        logger.debug { "Relinquished native memory pointer=${imageBlobPtr.pointerString()}" }
+    }
+
+    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup, arena: Arena)
+    fun readImageBlob(
+        magickWandPtr: MemorySegment,
+        bytes: ByteArray,
+    ) {
+        /**
+         * MagickBooleanType MagickReadImageBlob(MagickWand *wand, const void *blob,const size_t length)
+         */
+        val readImageBlobCall =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickReadImageBlob"),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG),
+            )
+
+        val imageBytePtr = arena.allocate(bytes.size.toLong())
+        MemorySegment.copy(bytes, 0, imageBytePtr, ValueLayout.JAVA_BYTE, 0, bytes.size)
+
+        logger.debug {
+            "Reading image blob into wand pointer=${magickWandPtr.pointerString()}, byteSize=${bytes.size}"
+        }
+        val result = readImageBlobCall.invoke(magickWandPtr, imageBytePtr, bytes.size.toLong()) == MAGICK_BOOLEAN_TRUE
+        requireSuccess(result, "MagickReadImageBlob", magickWandPtr)
+        logger.debug {
+            "Read image blob into wand pointer=${magickWandPtr.pointerString()}, byteSize=${bytes.size}"
+        }
+    }
+
+    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup, arena: Arena)
+    fun getImageBlob(magickWandPtr: MemorySegment): ImageBlob {
+        /**
+         * unsigned char *MagickGetImageBlob(MagickWand *wand,size_t *length)
+         */
+        val magickGetImageBlobCall =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickGetImageBlob"),
+                FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
+            )
+
+        val imageSizePtr = arena.allocate(ValueLayout.JAVA_LONG)
+        val imageBlobPtr = magickGetImageBlobCall.invoke(magickWandPtr, imageSizePtr) as MemorySegment
+        if (imageBlobPtr == MemorySegment.NULL) {
+            failOperation("MagickGetImageBlob", magickWandPtr)
+        }
+        val imageSize = imageSizePtr.get(ValueLayout.JAVA_LONG, 0)
+        val imageBytes = imageBlobPtr.reinterpret(imageSize).asReadOnly().toArray(ValueLayout.JAVA_BYTE)
+        logger.debug {
+            "Fetched image blob from wand pointer=${magickWandPtr.pointerString()}, byteSize=$imageSize"
+        }
+        return ImageBlob(
+            size = imageSize,
+            blobPtr = imageBlobPtr,
+            bytes = imageBytes,
+        )
+    }
+
+    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup, arena: Arena)
+    fun writeImage(
+        magickWandPtr: MemorySegment,
+        outputAbsPath: String,
+    ) {
+        /**
+         * MagickBooleanType MagickWriteImage(MagickWand *wand, const char *filename)
+         */
+        val magickWriteImageCall =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickWriteImage"),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
+            )
+        logger.debug {
+            "Writing image from wand pointer=${magickWandPtr.pointerString()} to path=$outputAbsPath"
+        }
+        val result = magickWriteImageCall.invoke(magickWandPtr, arena.allocateFrom(outputAbsPath)) == MAGICK_BOOLEAN_TRUE
+        requireSuccess(result, "MagickWriteImage", magickWandPtr)
+        logger.debug {
+            "Wrote image from wand pointer=${magickWandPtr.pointerString()} to path=$outputAbsPath"
+        }
+    }
+
+    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    fun resizeImage(
+        magickWandPtr: MemorySegment,
+        width: Long,
+        height: Long,
+        filter: FilterType = FilterType.LanczosFilter,
+    ) {
+        /**
+         * MagickBooleanType MagickResizeImage(MagickWand *wand, const size_t columns,const size_t rows,const FilterType filter)
+         */
+        val magickResizeImageCall =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickResizeImage"),
+                FunctionDescriptor.of(
+                    ValueLayout.JAVA_INT,
+                    ValueLayout.ADDRESS,
+                    ValueLayout.JAVA_LONG,
+                    ValueLayout.JAVA_LONG,
+                    ValueLayout.JAVA_INT,
+                ),
+            )
+        logger.debug {
+            "Resizing image in wand pointer=${magickWandPtr.pointerString()} to ${width}x$height"
+        }
+        val result = magickResizeImageCall.invoke(magickWandPtr, width, height, filter.ordinal) == MAGICK_BOOLEAN_TRUE
+        requireSuccess(result, "MagickResizeImage", magickWandPtr)
+        logger.debug {
+            "Resized image in wand pointer=${magickWandPtr.pointerString()} to ${width}x$height"
+        }
+    }
+
+    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    fun scaleImage(
+        magickWandPtr: MemorySegment,
+        width: Long,
+        height: Long,
+    ) {
+        /**
+         * MagickBooleanType MagickScaleImage(MagickWand *wand, const size_t columns,const size_t rows)
+         */
+        val magickScaleImageCall =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickScaleImage"),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG),
+            )
+        logger.debug {
+            "Scaling image in wand pointer=${magickWandPtr.pointerString()} to ${width}x$height"
+        }
+        val result = magickScaleImageCall.invoke(magickWandPtr, width, height) == MAGICK_BOOLEAN_TRUE
+        requireSuccess(result, "MagickScaleImage", magickWandPtr)
+        logger.debug {
+            "Scaled image in wand pointer=${magickWandPtr.pointerString()} to ${width}x$height"
+        }
+    }
+
+    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    fun thumbnailImage(
+        magickWandPtr: MemorySegment,
+        width: Long,
+        height: Long,
+    ) {
+        /**
+         * MagickBooleanType MagickThumbnailImage(MagickWand *wand, const size_t columns,const size_t rows)
+         */
+        val magickThumbnailImageCall =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickThumbnailImage"),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG),
+            )
+        logger.debug {
+            "Generating thumbnail in wand pointer=${magickWandPtr.pointerString()} with bounds ${width}x$height"
+        }
+        val result = magickThumbnailImageCall.invoke(magickWandPtr, width, height) == MAGICK_BOOLEAN_TRUE
+        requireSuccess(result, "MagickThumbnailImage", magickWandPtr)
+        logger.debug {
+            "Generated thumbnail in wand pointer=${magickWandPtr.pointerString()} with bounds ${width}x$height"
+        }
+    }
+
+    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup, arena: Arena)
+    fun setImageFormat(
+        magickWandPtr: MemorySegment,
+        type: ImageType,
+    ) {
+        /**
+         * MagickBooleanType MagickSetImageFormat(MagickWand *wand, const char *format)
+         */
+        val magickSetImageFormatCall =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickSetImageFormat"),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
+            )
+        logger.debug {
+            "Setting image format for wand pointer=${magickWandPtr.pointerString()} to ${type.name}"
+        }
+        val result = magickSetImageFormatCall.invoke(magickWandPtr, arena.allocateFrom(type.name)) == MAGICK_BOOLEAN_TRUE
+        requireSuccess(result, "MagickSetImageFormat", magickWandPtr)
+        logger.debug {
+            "Set image format for wand pointer=${magickWandPtr.pointerString()} to ${type.name}"
+        }
+    }
+
+    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    fun setImageQuality(
+        magickWandPtr: MemorySegment,
+        quality: Double,
+    ) {
+        /**
+         * MagickBooleanType MagickSetImageCompressionQuality(MagickWand *wand, const size_t quality)
+         */
+        val magickSetImageCompressionQualityCall =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickSetImageCompressionQuality"),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG),
+            )
+        val normalizedQuality = (quality * 100).toLong().coerceIn(0, 100)
+        logger.debug {
+            "Setting image quality for wand pointer=${magickWandPtr.pointerString()} to $normalizedQuality"
+        }
+        val result = magickSetImageCompressionQualityCall.invoke(magickWandPtr, normalizedQuality) == MAGICK_BOOLEAN_TRUE
+        requireSuccess(result, "MagickSetImageCompressionQuality", magickWandPtr)
+        logger.debug {
+            "Set image quality for wand pointer=${magickWandPtr.pointerString()} to $normalizedQuality"
+        }
+    }
+
+    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    fun getExceptionType(magickWandPtr: MemorySegment): Long {
+        /**
+         * ExceptionType MagickGetExceptionType(const MagickWand *)
+         */
+        val magickGetExceptionTypeCall =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickGetExceptionType"),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS),
+            )
+        val exceptionType = magickGetExceptionTypeCall.invoke(magickWandPtr) as Int
+        logger.debug {
+            "Fetched ImageMagick exception type=$exceptionType from wand pointer=${magickWandPtr.pointerString()}"
+        }
+        return exceptionType.toLong()
+    }
+
+    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    fun getException(magickWandPtr: MemorySegment): String {
+        /**
+         * char *MagickGetException(const MagickWand *,ExceptionType *)
+         */
+        val exceptionInfo = fetchExceptionInfo(magickWandPtr)
+        logger.debug {
+            "Fetched ImageMagick exception from wand pointer=${magickWandPtr.pointerString()} " +
+                "[type=${exceptionInfo.type}]: ${exceptionInfo.message}"
+        }
+        return exceptionInfo.message
+    }
+
+    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    private fun requireSuccess(
+        succeeded: Boolean,
+        operation: String,
+        magickWandPtr: MemorySegment,
+    ) {
+        if (!succeeded) failOperation(operation, magickWandPtr)
+    }
+
+    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    private fun failOperation(
+        operation: String,
+        magickWandPtr: MemorySegment,
+    ): Nothing {
+        val exceptionInfo = fetchExceptionInfo(magickWandPtr)
+        val message = "ImageMagick $operation failed [type=${exceptionInfo.type}]: ${exceptionInfo.message}"
+        logger.error { message }
+        throw ImageOperationException(message)
+    }
+
+    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    private fun fetchExceptionInfo(magickWandPtr: MemorySegment): MagickExceptionInfo =
+        Arena.ofConfined().use { arena ->
+            val magickGetExceptionCall =
+                linker.downcallHandle(
+                    imageMagickLib.findOrThrow("MagickGetException"),
+                    FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
+                )
+            val exceptionTypePtr = arena.allocate(ValueLayout.JAVA_INT)
+            val exceptionMsgPtr = magickGetExceptionCall.invoke(magickWandPtr, exceptionTypePtr) as MemorySegment
+            val exceptionType = exceptionTypePtr.get(ValueLayout.JAVA_INT, 0)
+            if (exceptionMsgPtr == MemorySegment.NULL) {
+                return@use MagickExceptionInfo(
+                    type = exceptionType,
+                    message = "Unknown ImageMagick error",
+                )
+            }
+
+            val exceptionMessage =
+                try {
+                    exceptionMsgPtr.reinterpret(MAX_EXCEPTION_MESSAGE_SIZE).getString(0)
+                } finally {
+                    relinquishMemory(exceptionMsgPtr)
+                }
+
+            MagickExceptionInfo(
+                type = exceptionType,
+                message = exceptionMessage.ifBlank { "Unknown ImageMagick error" },
+            )
+        }
+
+    private fun MemorySegment.pointerString(): String = "0x${address().toString(16)}"
+}
+
+/**
+ * https://github.com/ImageMagick/ImageMagick/blob/51291c38859f78e9c03fef061e8c310354a4d07a/MagickCore/resample.h#L69
+ */
+@Suppress("unused")
+enum class FilterType {
+    UndefinedFilter,
+    PointFilter,
+    BoxFilter,
+    TriangleFilter,
+    HermiteFilter,
+    HannFilter,
+    HammingFilter,
+    BlackmanFilter,
+    GaussianFilter,
+    QuadraticFilter,
+    CubicFilter,
+    CatromFilter,
+    MitchellFilter,
+    JincFilter,
+    SincFilter,
+    SincFastFilter,
+    KaiserFilter,
+    WelchFilter,
+    ParzenFilter,
+    BohmanFilter,
+    BartlettFilter,
+    LagrangeFilter,
+    LanczosFilter,
+    LanczosSharpFilter,
+    Lanczos2Filter,
+    Lanczos2SharpFilter,
+    RobidouxFilter,
+    RobidouxSharpFilter,
+    CosineFilter,
+    SplineFilter,
+    LanczosRadiusFilter,
+    CubicSplineFilter,
+    MagicKernelSharp2013Filter,
+    MagicKernelSharp2021Filter,
+
+    // a count of all the filters, not a real filter
+    SentinelFilter,
+}
+
+private data class MagickExceptionInfo(
+    val type: Int,
+    val message: String,
+)
+
+data class ImageBlob(
+    val size: Long,
+    val blobPtr: MemorySegment,
+    val bytes: ByteArray,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ImageBlob
+
+        if (size != other.size) return false
+        if (blobPtr != other.blobPtr) return false
+        if (!bytes.contentEquals(other.bytes)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = size.hashCode()
+        result = 31 * result + blobPtr.hashCode()
+        result = 31 * result + bytes.contentHashCode()
+        return result
+    }
+}

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/native/ImageOperation.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/native/ImageOperation.kt
@@ -364,13 +364,13 @@ object ImageOperation {
     context(logger: KLogger)
     fun setImageQuality(
         magickWandPtr: MemorySegment,
-        quality: Double,
+        quality: Int,
     ) {
         /**
          * MagickBooleanType MagickSetImageCompressionQuality(MagickWand *wand, const size_t quality)
          */
         val magickSetImageCompressionQualityCall = methodHandleDict.getValue("MagickSetImageCompressionQuality")
-        val normalizedQuality = (quality * 100).toLong().coerceIn(0, 100)
+        val normalizedQuality = quality.toLong().coerceAtMost(100)
         logger.debug {
             "Setting image quality for wand pointer=${magickWandPtr.pointerString()} to $normalizedQuality"
         }

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/native/ImageOperation.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/native/ImageOperation.kt
@@ -1,6 +1,8 @@
 package io.sakurasou.hoshizora.native
 
 import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.sakurasou.hoshizora.di.inject
 import io.sakurasou.hoshizora.exception.native.ImageOperationException
 import io.sakurasou.hoshizora.model.group.ImageType
 import java.lang.foreign.Arena
@@ -9,6 +11,7 @@ import java.lang.foreign.Linker
 import java.lang.foreign.MemorySegment
 import java.lang.foreign.SymbolLookup
 import java.lang.foreign.ValueLayout
+import java.lang.invoke.MethodHandle
 
 /**
  * @author Shiina Kin
@@ -17,38 +20,123 @@ import java.lang.foreign.ValueLayout
 object ImageOperation {
     private const val MAGICK_BOOLEAN_TRUE = 1
     private const val MAX_EXCEPTION_MESSAGE_SIZE = 4096L
+    private val methodHandleDict = mutableMapOf<String, MethodHandle>()
+
+    init {
+        val logger = KotlinLogging.logger {}
+        val linker: Linker by inject()
+        val imageMagickLib: SymbolLookup by inject()
+        context(logger, linker, imageMagickLib) {
+            initMethodHandles()
+            genesis()
+        }
+    }
 
     context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
-    fun genesis() {
-        val magickWandGenesisCall =
+    private fun initMethodHandles() {
+        methodHandleDict["MagickWandGenesis"] =
             linker.downcallHandle(
                 imageMagickLib.findOrThrow("MagickWandGenesis"),
                 FunctionDescriptor.ofVoid(),
             )
+        methodHandleDict["MagickWandTerminus"] =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickWandTerminus"),
+                FunctionDescriptor.ofVoid(),
+            )
+        methodHandleDict["NewMagickWand"] =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("NewMagickWand"),
+                FunctionDescriptor.of(ValueLayout.ADDRESS),
+            )
+        methodHandleDict["DestroyMagickWand"] =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("DestroyMagickWand"),
+                FunctionDescriptor.ofVoid(ValueLayout.ADDRESS),
+            )
+        methodHandleDict["MagickRelinquishMemory"] =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickRelinquishMemory"),
+                FunctionDescriptor.ofVoid(ValueLayout.ADDRESS),
+            )
+        methodHandleDict["MagickReadImageBlob"] =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickReadImageBlob"),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG),
+            )
+        methodHandleDict["MagickGetImageBlob"] =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickGetImageBlob"),
+                FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
+            )
+        methodHandleDict["MagickWriteImage"] =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickWriteImage"),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
+            )
+        methodHandleDict["MagickResizeImage"] =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickResizeImage"),
+                FunctionDescriptor.of(
+                    ValueLayout.JAVA_INT,
+                    ValueLayout.ADDRESS,
+                    ValueLayout.JAVA_LONG,
+                    ValueLayout.JAVA_LONG,
+                    ValueLayout.JAVA_INT,
+                ),
+            )
+        methodHandleDict["MagickScaleImage"] =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickScaleImage"),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG),
+            )
+        methodHandleDict["MagickThumbnailImage"] =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickThumbnailImage"),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG),
+            )
+        methodHandleDict["MagickSetImageFormat"] =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickSetImageFormat"),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
+            )
+        methodHandleDict["MagickSetImageCompressionQuality"] =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickSetImageCompressionQuality"),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG),
+            )
+        methodHandleDict["MagickGetExceptionType"] =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickGetExceptionType"),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS),
+            )
+        methodHandleDict["MagickGetException"] =
+            linker.downcallHandle(
+                imageMagickLib.findOrThrow("MagickGetException"),
+                FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
+            )
+        logger.info { "Initialized ImageMagick method handles" }
+    }
+
+    context(logger: KLogger)
+    fun genesis() {
+        val magickWandGenesisCall = methodHandleDict.getValue("MagickWandGenesis")
         logger.info { "Initializing ImageMagick runtime" }
         magickWandGenesisCall.invoke()
         logger.info { "ImageMagick initialized" }
     }
 
-    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    context(logger: KLogger)
     fun terminus() {
-        val magickWandTerminusCall =
-            linker.downcallHandle(
-                imageMagickLib.findOrThrow("MagickWandTerminus"),
-                FunctionDescriptor.ofVoid(),
-            )
+        val magickWandTerminusCall = methodHandleDict.getValue("MagickWandTerminus")
         logger.info { "Terminating ImageMagick runtime" }
         magickWandTerminusCall.invoke()
         logger.info { "ImageMagick terminated" }
     }
 
-    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    context(logger: KLogger)
     fun newMagickWand(): MemorySegment {
-        val newMagickWandCall =
-            linker.downcallHandle(
-                imageMagickLib.findOrThrow("NewMagickWand"),
-                FunctionDescriptor.of(ValueLayout.ADDRESS),
-            )
+        val newMagickWandCall = methodHandleDict.getValue("NewMagickWand")
         val magickWandPtr = newMagickWandCall.invoke() as MemorySegment
         if (magickWandPtr == MemorySegment.NULL) {
             logger.error { "Failed to create MagickWand: native call returned NULL" }
@@ -58,29 +146,21 @@ object ImageOperation {
         return magickWandPtr
     }
 
-    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    context(logger: KLogger)
     fun destroyMagickWand(magickWandPtr: MemorySegment) {
-        val destroyMagickWandCall =
-            linker.downcallHandle(
-                imageMagickLib.findOrThrow("DestroyMagickWand"),
-                FunctionDescriptor.ofVoid(ValueLayout.ADDRESS),
-            )
+        val destroyMagickWandCall = methodHandleDict.getValue("DestroyMagickWand")
         destroyMagickWandCall.invoke(magickWandPtr)
         logger.debug { "Destroyed MagickWand pointer=${magickWandPtr.pointerString()}" }
     }
 
-    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    context(logger: KLogger)
     fun relinquishMemory(imageBlobPtr: MemorySegment) {
-        val relinquishMemoryCall =
-            linker.downcallHandle(
-                imageMagickLib.findOrThrow("MagickRelinquishMemory"),
-                FunctionDescriptor.ofVoid(ValueLayout.ADDRESS),
-            )
+        val relinquishMemoryCall = methodHandleDict.getValue("MagickRelinquishMemory")
         relinquishMemoryCall.invoke(imageBlobPtr)
         logger.debug { "Relinquished native memory pointer=${imageBlobPtr.pointerString()}" }
     }
 
-    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup, arena: Arena)
+    context(logger: KLogger, arena: Arena)
     fun readImageBlob(
         magickWandPtr: MemorySegment,
         bytes: ByteArray,
@@ -88,11 +168,7 @@ object ImageOperation {
         /**
          * MagickBooleanType MagickReadImageBlob(MagickWand *wand, const void *blob,const size_t length)
          */
-        val readImageBlobCall =
-            linker.downcallHandle(
-                imageMagickLib.findOrThrow("MagickReadImageBlob"),
-                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG),
-            )
+        val readImageBlobCall = methodHandleDict.getValue("MagickReadImageBlob")
 
         val imageBytePtr = arena.allocate(bytes.size.toLong())
         MemorySegment.copy(bytes, 0, imageBytePtr, ValueLayout.JAVA_BYTE, 0, bytes.size)
@@ -107,16 +183,12 @@ object ImageOperation {
         }
     }
 
-    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup, arena: Arena)
+    context(logger: KLogger, arena: Arena)
     fun getImageBlob(magickWandPtr: MemorySegment): ImageBlob {
         /**
          * unsigned char *MagickGetImageBlob(MagickWand *wand,size_t *length)
          */
-        val magickGetImageBlobCall =
-            linker.downcallHandle(
-                imageMagickLib.findOrThrow("MagickGetImageBlob"),
-                FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
-            )
+        val magickGetImageBlobCall = methodHandleDict.getValue("MagickGetImageBlob")
 
         val imageSizePtr = arena.allocate(ValueLayout.JAVA_LONG)
         val imageBlobPtr = magickGetImageBlobCall.invoke(magickWandPtr, imageSizePtr) as MemorySegment
@@ -135,7 +207,7 @@ object ImageOperation {
         )
     }
 
-    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup, arena: Arena)
+    context(logger: KLogger, arena: Arena)
     fun writeImage(
         magickWandPtr: MemorySegment,
         outputAbsPath: String,
@@ -143,11 +215,7 @@ object ImageOperation {
         /**
          * MagickBooleanType MagickWriteImage(MagickWand *wand, const char *filename)
          */
-        val magickWriteImageCall =
-            linker.downcallHandle(
-                imageMagickLib.findOrThrow("MagickWriteImage"),
-                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
-            )
+        val magickWriteImageCall = methodHandleDict.getValue("MagickWriteImage")
         logger.debug {
             "Writing image from wand pointer=${magickWandPtr.pointerString()} to path=$outputAbsPath"
         }
@@ -158,7 +226,7 @@ object ImageOperation {
         }
     }
 
-    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    context(logger: KLogger)
     fun resizeImage(
         magickWandPtr: MemorySegment,
         width: Long,
@@ -168,17 +236,7 @@ object ImageOperation {
         /**
          * MagickBooleanType MagickResizeImage(MagickWand *wand, const size_t columns,const size_t rows,const FilterType filter)
          */
-        val magickResizeImageCall =
-            linker.downcallHandle(
-                imageMagickLib.findOrThrow("MagickResizeImage"),
-                FunctionDescriptor.of(
-                    ValueLayout.JAVA_INT,
-                    ValueLayout.ADDRESS,
-                    ValueLayout.JAVA_LONG,
-                    ValueLayout.JAVA_LONG,
-                    ValueLayout.JAVA_INT,
-                ),
-            )
+        val magickResizeImageCall = methodHandleDict.getValue("MagickResizeImage")
         logger.debug {
             "Resizing image in wand pointer=${magickWandPtr.pointerString()} to ${width}x$height"
         }
@@ -189,7 +247,7 @@ object ImageOperation {
         }
     }
 
-    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    context(logger: KLogger)
     fun scaleImage(
         magickWandPtr: MemorySegment,
         width: Long,
@@ -198,11 +256,7 @@ object ImageOperation {
         /**
          * MagickBooleanType MagickScaleImage(MagickWand *wand, const size_t columns,const size_t rows)
          */
-        val magickScaleImageCall =
-            linker.downcallHandle(
-                imageMagickLib.findOrThrow("MagickScaleImage"),
-                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG),
-            )
+        val magickScaleImageCall = methodHandleDict.getValue("MagickScaleImage")
         logger.debug {
             "Scaling image in wand pointer=${magickWandPtr.pointerString()} to ${width}x$height"
         }
@@ -213,7 +267,7 @@ object ImageOperation {
         }
     }
 
-    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    context(logger: KLogger)
     fun thumbnailImage(
         magickWandPtr: MemorySegment,
         width: Long,
@@ -222,11 +276,7 @@ object ImageOperation {
         /**
          * MagickBooleanType MagickThumbnailImage(MagickWand *wand, const size_t columns,const size_t rows)
          */
-        val magickThumbnailImageCall =
-            linker.downcallHandle(
-                imageMagickLib.findOrThrow("MagickThumbnailImage"),
-                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG),
-            )
+        val magickThumbnailImageCall = methodHandleDict.getValue("MagickThumbnailImage")
         logger.debug {
             "Generating thumbnail in wand pointer=${magickWandPtr.pointerString()} with bounds ${width}x$height"
         }
@@ -237,7 +287,7 @@ object ImageOperation {
         }
     }
 
-    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup, arena: Arena)
+    context(logger: KLogger, arena: Arena)
     fun setImageFormat(
         magickWandPtr: MemorySegment,
         type: ImageType,
@@ -245,11 +295,7 @@ object ImageOperation {
         /**
          * MagickBooleanType MagickSetImageFormat(MagickWand *wand, const char *format)
          */
-        val magickSetImageFormatCall =
-            linker.downcallHandle(
-                imageMagickLib.findOrThrow("MagickSetImageFormat"),
-                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
-            )
+        val magickSetImageFormatCall = methodHandleDict.getValue("MagickSetImageFormat")
         logger.debug {
             "Setting image format for wand pointer=${magickWandPtr.pointerString()} to ${type.name}"
         }
@@ -260,7 +306,7 @@ object ImageOperation {
         }
     }
 
-    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    context(logger: KLogger)
     fun setImageQuality(
         magickWandPtr: MemorySegment,
         quality: Double,
@@ -268,11 +314,7 @@ object ImageOperation {
         /**
          * MagickBooleanType MagickSetImageCompressionQuality(MagickWand *wand, const size_t quality)
          */
-        val magickSetImageCompressionQualityCall =
-            linker.downcallHandle(
-                imageMagickLib.findOrThrow("MagickSetImageCompressionQuality"),
-                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG),
-            )
+        val magickSetImageCompressionQualityCall = methodHandleDict.getValue("MagickSetImageCompressionQuality")
         val normalizedQuality = (quality * 100).toLong().coerceIn(0, 100)
         logger.debug {
             "Setting image quality for wand pointer=${magickWandPtr.pointerString()} to $normalizedQuality"
@@ -284,16 +326,12 @@ object ImageOperation {
         }
     }
 
-    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    context(logger: KLogger)
     fun getExceptionType(magickWandPtr: MemorySegment): Long {
         /**
          * ExceptionType MagickGetExceptionType(const MagickWand *)
          */
-        val magickGetExceptionTypeCall =
-            linker.downcallHandle(
-                imageMagickLib.findOrThrow("MagickGetExceptionType"),
-                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS),
-            )
+        val magickGetExceptionTypeCall = methodHandleDict.getValue("MagickGetExceptionType")
         val exceptionType = magickGetExceptionTypeCall.invoke(magickWandPtr) as Int
         logger.debug {
             "Fetched ImageMagick exception type=$exceptionType from wand pointer=${magickWandPtr.pointerString()}"
@@ -301,7 +339,7 @@ object ImageOperation {
         return exceptionType.toLong()
     }
 
-    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    context(logger: KLogger)
     fun getException(magickWandPtr: MemorySegment): String {
         /**
          * char *MagickGetException(const MagickWand *,ExceptionType *)
@@ -314,7 +352,7 @@ object ImageOperation {
         return exceptionInfo.message
     }
 
-    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    context(logger: KLogger)
     private fun requireSuccess(
         succeeded: Boolean,
         operation: String,
@@ -323,7 +361,7 @@ object ImageOperation {
         if (!succeeded) failOperation(operation, magickWandPtr)
     }
 
-    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    context(logger: KLogger)
     private fun failOperation(
         operation: String,
         magickWandPtr: MemorySegment,
@@ -334,14 +372,10 @@ object ImageOperation {
         throw ImageOperationException(message)
     }
 
-    context(logger: KLogger, linker: Linker, imageMagickLib: SymbolLookup)
+    context(logger: KLogger)
     private fun fetchExceptionInfo(magickWandPtr: MemorySegment): MagickExceptionInfo =
         Arena.ofConfined().use { arena ->
-            val magickGetExceptionCall =
-                linker.downcallHandle(
-                    imageMagickLib.findOrThrow("MagickGetException"),
-                    FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS),
-                )
+            val magickGetExceptionCall = methodHandleDict.getValue("MagickGetException")
             val exceptionTypePtr = arena.allocate(ValueLayout.JAVA_INT)
             val exceptionMsgPtr = magickGetExceptionCall.invoke(magickWandPtr, exceptionTypePtr) as MemorySegment
             val exceptionType = exceptionTypePtr.get(ValueLayout.JAVA_INT, 0)

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/service/image/ImageServiceImpl.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/service/image/ImageServiceImpl.kt
@@ -116,11 +116,10 @@ class ImageServiceImpl(
                             if (groupConfig.groupStrategyConfig.imageQuality != 100) {
                                 val quality = groupConfig.groupStrategyConfig.imageQuality
                                 if (quality !in (1..100)) throw IllegalArgumentException("Image quality must be in 1..100")
-                                val imageQuality = quality / 1.0
                                 ImageUtils.transformImage(
                                     imageBytes,
                                     groupConfig.groupStrategyConfig.imageAutoTransformTarget,
-                                    imageQuality,
+                                    quality,
                                 )
                             } else {
                                 ImageUtils.transformImage(imageBytes, groupConfig.groupStrategyConfig.imageAutoTransformTarget)

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/service/image/ImageServiceImpl.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/service/image/ImageServiceImpl.kt
@@ -110,27 +110,28 @@ class ImageServiceImpl(
                 // transform image if needed
                 var size = imageRawFile.size
                 var imageBytes = imageRawFile.bytes
-                var image = ByteArrayInputStream(imageBytes).use { ImageIO.read(it) }
-                if (groupConfig.groupStrategyConfig.imageAutoTransformTarget != null) {
-                    imageBytes =
-                        if (groupConfig.groupStrategyConfig.imageQuality != 100) {
-                            val quality = groupConfig.groupStrategyConfig.imageQuality
-                            if (quality !in (1..100)) throw IllegalArgumentException("Image quality must be in 1..100")
-                            val imageQuality = quality / 1.0
-                            ImageUtils.transformImage(
-                                image,
-                                groupConfig.groupStrategyConfig.imageAutoTransformTarget,
-                                imageQuality,
-                            )
-                        } else {
-                            ImageUtils.transformImage(image, groupConfig.groupStrategyConfig.imageAutoTransformTarget)
-                        }
-                    extension =
-                        groupConfig.groupStrategyConfig.imageAutoTransformTarget.name
-                            .lowercase()
+                context(logger) {
+                    if (groupConfig.groupStrategyConfig.imageAutoTransformTarget != null) {
+                        imageBytes =
+                            if (groupConfig.groupStrategyConfig.imageQuality != 100) {
+                                val quality = groupConfig.groupStrategyConfig.imageQuality
+                                if (quality !in (1..100)) throw IllegalArgumentException("Image quality must be in 1..100")
+                                val imageQuality = quality / 1.0
+                                ImageUtils.transformImage(
+                                    imageBytes,
+                                    groupConfig.groupStrategyConfig.imageAutoTransformTarget,
+                                    imageQuality,
+                                )
+                            } else {
+                                ImageUtils.transformImage(imageBytes, groupConfig.groupStrategyConfig.imageAutoTransformTarget)
+                            }
+                        extension =
+                            groupConfig.groupStrategyConfig.imageAutoTransformTarget.name
+                                .lowercase()
+                    }
                     size = imageBytes.size.toLong()
-                    image = ByteArrayInputStream(imageBytes).use { ImageIO.read(it) }
                 }
+                val image = ByteArrayInputStream(imageBytes).use { ImageIO.read(it) }
                 val md5 = DigestUtils.md5Hex(imageBytes)
                 val sha256 = DigestUtils.sha256Hex(imageBytes)
 

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/util/ImageUtils.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/util/ImageUtils.kt
@@ -1,19 +1,17 @@
 package io.sakurasou.hoshizora.util
 
+import io.github.oshai.kotlinlogging.KLogger
 import io.sakurasou.hoshizora.exception.service.image.io.ImageFileNotFoundException
 import io.sakurasou.hoshizora.model.entity.Strategy
 import io.sakurasou.hoshizora.model.group.ImageType
 import io.sakurasou.hoshizora.model.strategy.LocalStrategy
 import io.sakurasou.hoshizora.model.strategy.S3Strategy
 import io.sakurasou.hoshizora.model.strategy.WebDavStrategy
+import io.sakurasou.hoshizora.native.ImageBlob
+import io.sakurasou.hoshizora.native.ImageOperation
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.im4java.core.ConvertCmd
-import org.im4java.core.IMOperation
-import org.im4java.process.OutputConsumer
-import java.awt.image.BufferedImage
-import java.io.ByteArrayOutputStream
-import java.io.InputStream
+import java.lang.foreign.Arena
 
 /**
  * @author Shiina Kin
@@ -121,101 +119,127 @@ object ImageUtils {
             }
         }
 
+    context(logger: KLogger)
     suspend fun transformImage(
-        rawImage: BufferedImage,
+        rawImageBytes: ByteArray,
         targetImageType: ImageType,
     ): ByteArray =
         withContext(Dispatchers.IO) {
-            val imageOp =
-                IMOperation().apply {
-                    addImage()
-                    addImage("${targetImageType.name}:-")
+            Arena.ofConfined().use { arena ->
+                context(arena) {
+                    val wand = ImageOperation.newMagickWand()
+                    var imageBlob: ImageBlob? = null
+                    try {
+                        ImageOperation.readImageBlob(wand, rawImageBytes)
+                        ImageOperation.setImageFormat(wand, targetImageType)
+                        imageBlob = ImageOperation.getImageBlob(wand)
+                    } finally {
+                        imageBlob?.let { ImageOperation.relinquishMemory(it.blobPtr) }
+                        ImageOperation.destroyMagickWand(wand)
+                    }
+                    imageBlob.bytes
                 }
-            execTransform(imageOp, rawImage)
+            }
         }
 
+    context(logger: KLogger)
     suspend fun transformImage(
-        rawImage: BufferedImage,
+        rawImageBytes: ByteArray,
         targetImageType: ImageType,
         quality: Double,
     ): ByteArray =
         withContext(Dispatchers.IO) {
-            val imageOp =
-                IMOperation().apply {
-                    addImage()
-                    quality(quality)
-                    addImage("${targetImageType.name}:-")
+            Arena.ofConfined().use { arena ->
+                context(arena) {
+                    val wand = ImageOperation.newMagickWand()
+                    var imageBlob: ImageBlob? = null
+                    try {
+                        ImageOperation.readImageBlob(wand, rawImageBytes)
+                        ImageOperation.setImageFormat(wand, targetImageType)
+                        ImageOperation.setImageQuality(wand, quality)
+                        imageBlob = ImageOperation.getImageBlob(wand)
+                    } finally {
+                        imageBlob?.let { ImageOperation.relinquishMemory(it.blobPtr) }
+                        ImageOperation.destroyMagickWand(wand)
+                    }
+                    imageBlob.bytes
                 }
-            execTransform(imageOp, rawImage)
+            }
         }
 
+    context(logger: KLogger)
     private suspend fun transformImage(
-        rawImage: BufferedImage,
+        rawImageBytes: ByteArray,
         targetImageType: ImageType,
-        newWidth: Int,
-        newHeight: Int,
+        targetWidth: Long? = null,
+        targetHeight: Long? = null,
         quality: Double,
     ): ByteArray =
         withContext(Dispatchers.IO) {
-            val imageOp =
-                IMOperation().apply {
-                    addImage()
-                    resize(newWidth, newHeight)
-                    quality(quality)
-                    addImage("${targetImageType.name}:-")
+            Arena.ofConfined().use { arena ->
+                context(arena) {
+                    val wand = ImageOperation.newMagickWand()
+                    var imageBlob: ImageBlob? = null
+                    try {
+                        ImageOperation.readImageBlob(wand, rawImageBytes)
+                        val originalWidth = ImageOperation.getImageWidth(wand)
+                        val originalHeight = ImageOperation.getImageHeight(wand)
+                        val (newWidth, newHeight) =
+                            when {
+                                targetWidth != null && targetHeight != null -> {
+                                    targetWidth to targetHeight
+                                }
+
+                                targetWidth != null -> {
+                                    targetWidth to (originalHeight * targetWidth) / originalWidth
+                                }
+
+                                targetHeight != null -> {
+                                    (originalWidth * targetHeight) / originalHeight to targetHeight
+                                }
+
+                                else -> {
+                                    originalWidth to originalHeight
+                                }
+                            }
+                        ImageOperation.setImageFormat(wand, targetImageType)
+                        ImageOperation.setImageQuality(wand, quality)
+                        ImageOperation.resizeImage(wand, newWidth, newHeight)
+                        imageBlob = ImageOperation.getImageBlob(wand)
+                    } finally {
+                        imageBlob?.let { ImageOperation.relinquishMemory(it.blobPtr) }
+                        ImageOperation.destroyMagickWand(wand)
+                    }
+                    imageBlob.bytes
                 }
-            execTransform(imageOp, rawImage)
+            }
         }
 
-    private fun execTransform(
-        imageOp: IMOperation,
-        rawImage: BufferedImage,
-    ): ByteArray =
-        ConvertCmd().let { cmd ->
-            val outputConverter = CustomOutputConsumer()
-            cmd.setOutputConsumer(outputConverter)
-            cmd.run(imageOp, rawImage)
-            outputConverter.getBytes()
-        }
-
-    /**
-     * will block cur thread
-     */
+    context(logger: KLogger)
     suspend fun transformImageByWidth(
-        rawImage: BufferedImage,
+        rawImageBytes: ByteArray,
         targetImageType: ImageType,
-        newWidth: Int,
+        newWidth: Long,
         quality: Double,
-    ): ByteArray {
-        val originalWidth = rawImage.width
-        val originalHeight = rawImage.height
-        val newHeight = (originalHeight * newWidth) / originalWidth
-        return transformImage(rawImage, targetImageType, newWidth, newHeight, quality)
-    }
+    ): ByteArray =
+        transformImage(
+            rawImageBytes = rawImageBytes,
+            targetImageType = targetImageType,
+            targetWidth = newWidth,
+            quality = quality,
+        )
 
-    /**
-     * will block cur thread
-     */
+    context(logger: KLogger)
     suspend fun transformImageByHeight(
-        rawImage: BufferedImage,
+        rawImageBytes: ByteArray,
         targetImageType: ImageType,
-        newHeight: Int,
+        newHeight: Long,
         quality: Double,
-    ): ByteArray {
-        val originalWidth = rawImage.width
-        val originalHeight = rawImage.height
-        val newWidth = (originalWidth * newHeight) / originalHeight
-        return transformImage(rawImage, targetImageType, newWidth, newHeight, quality)
-    }
-
-    class CustomOutputConsumer : OutputConsumer {
-        private val outputStream = ByteArrayOutputStream()
-
-        override fun consumeOutput(inputStream: InputStream) {
-            inputStream.copyTo(outputStream)
-            inputStream.close()
-        }
-
-        fun getBytes(): ByteArray = outputStream.toByteArray().also { outputStream.close() }
-    }
+    ): ByteArray =
+        transformImage(
+            rawImageBytes = rawImageBytes,
+            targetImageType = targetImageType,
+            targetHeight = newHeight,
+            quality = quality,
+        )
 }

--- a/app/src/main/kotlin/io/sakurasou/hoshizora/util/ImageUtils.kt
+++ b/app/src/main/kotlin/io/sakurasou/hoshizora/util/ImageUtils.kt
@@ -146,7 +146,7 @@ object ImageUtils {
     suspend fun transformImage(
         rawImageBytes: ByteArray,
         targetImageType: ImageType,
-        quality: Double,
+        quality: Int,
     ): ByteArray =
         withContext(Dispatchers.IO) {
             Arena.ofConfined().use { arena ->
@@ -173,7 +173,7 @@ object ImageUtils {
         targetImageType: ImageType,
         targetWidth: Long? = null,
         targetHeight: Long? = null,
-        quality: Double,
+        quality: Int,
     ): ByteArray =
         withContext(Dispatchers.IO) {
             Arena.ofConfined().use { arena ->
@@ -220,7 +220,7 @@ object ImageUtils {
         rawImageBytes: ByteArray,
         targetImageType: ImageType,
         newWidth: Long,
-        quality: Double,
+        quality: Int,
     ): ByteArray =
         transformImage(
             rawImageBytes = rawImageBytes,
@@ -234,7 +234,7 @@ object ImageUtils {
         rawImageBytes: ByteArray,
         targetImageType: ImageType,
         newHeight: Long,
-        quality: Double,
+        quality: Int,
     ): ByteArray =
         transformImage(
             rawImageBytes = rawImageBytes,

--- a/app/src/main/resources/application.yaml
+++ b/app/src/main/resources/application.yaml
@@ -28,4 +28,6 @@ jwt:
   audience: $JWT_AUDIENCE
   realm: $JWT_REALM
 native:
-  imagemagick: $MAGICK_PATH
+  imagemagick:
+    magickwand:
+      lib: $MAGICK_WAND_LIB_PATH

--- a/app/src/main/resources/application.yaml
+++ b/app/src/main/resources/application.yaml
@@ -27,3 +27,5 @@ jwt:
   issuer: $JWT_ISSUER
   audience: $JWT_AUDIENCE
   realm: $JWT_REALM
+native:
+  imagemagick: $MAGICK_PATH

--- a/app/src/test/kotlin/io/sakurasou/hoshizora/native/ImageOperationTest.kt
+++ b/app/src/test/kotlin/io/sakurasou/hoshizora/native/ImageOperationTest.kt
@@ -9,6 +9,7 @@ import io.sakurasou.hoshizora.di.DI
 import io.sakurasou.hoshizora.di.DIManager
 import io.sakurasou.hoshizora.exception.native.ImageOperationException
 import io.sakurasou.hoshizora.model.group.ImageType
+import org.junit.Assume.assumeTrue
 import java.io.ByteArrayInputStream
 import java.lang.foreign.Arena
 import java.lang.foreign.Linker
@@ -34,9 +35,12 @@ class ImageOperationTest {
     private lateinit var infoMessages: MutableList<String>
     private lateinit var debugMessages: MutableList<String>
     private lateinit var errorMessages: MutableList<String>
+    private lateinit var imageMagickLibraryPath: Path
 
     @BeforeTest
     fun setUp() {
+        imageMagickLibraryPath = resolveImageMagickLibraryPath()
+
         logger = mockk(relaxed = true)
         infoMessages = mutableListOf()
         debugMessages = mutableListOf()
@@ -241,7 +245,7 @@ class ImageOperationTest {
 
     private fun ensureImageOperationInitialized() {
         val linker = Linker.nativeLinker()
-        val imageMagickLib = SymbolLookup.libraryLookup(resolveImageMagickLibraryPath(), Arena.global())
+        val imageMagickLib = SymbolLookup.libraryLookup(imageMagickLibraryPath, Arena.global())
         val di = mockk<DI>()
         every { di.get(Linker::class) } returns linker
         every { di.get(SymbolLookup::class) } returns imageMagickLib
@@ -296,22 +300,22 @@ class ImageOperationTest {
     }
 
     private fun resolveImageMagickLibraryPath(): Path {
-        val configuredPath = System.getenv("MAGICK_WAND_LIBRARY")?.takeIf { it.isNotBlank() }?.let(Path::of)
-        val candidates =
-            listOfNotNull(
-                configuredPath,
-                Path.of("/opt/homebrew/lib/libMagickWand-7.Q16HDRI.dylib"),
-                Path.of("/usr/local/lib/libMagickWand-7.Q16HDRI.dylib"),
-                Path.of("/usr/lib/libMagickWand-7.Q16HDRI.so"),
-                Path.of("/usr/lib64/libMagickWand-7.Q16HDRI.so"),
-                Path.of("/lib/aarch64-linux-gnu/libMagickWand-7.Q16HDRI.so"),
-            )
-
-        return candidates.firstOrNull(Files::exists)
-            ?: error("Unable to locate libMagickWand. Set MAGICK_WAND_LIBRARY to the installed library path.")
+        val configuredPath =
+            System.getenv(MAGICK_WAND_LIB_PATH_ENV)
+                ?.takeIf { it.isNotBlank() }
+                ?.let(Path::of)
+                ?.takeIf(Files::exists)
+        val skippedMessage = "Unable to locate libMagickWand. Set $MAGICK_WAND_LIB_PATH_ENV to the installed library path."
+        assumeTrue(
+            skippedMessage,
+            configuredPath != null,
+        )
+        return configuredPath ?: error(skippedMessage)
     }
 
     private companion object {
+        private const val MAGICK_WAND_LIB_PATH_ENV = "MAGICK_WAND_LIB_PATH"
+
         private val sourceImageBytes: ByteArray by lazy {
             ImageOperationTest::class.java.classLoader
                 .getResourceAsStream("test-img.png")

--- a/app/src/test/kotlin/io/sakurasou/hoshizora/native/ImageOperationTest.kt
+++ b/app/src/test/kotlin/io/sakurasou/hoshizora/native/ImageOperationTest.kt
@@ -3,6 +3,10 @@ package io.sakurasou.hoshizora.native
 import io.github.oshai.kotlinlogging.KLogger
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.sakurasou.hoshizora.di.DI
+import io.sakurasou.hoshizora.di.DIManager
 import io.sakurasou.hoshizora.exception.native.ImageOperationException
 import io.sakurasou.hoshizora.model.group.ImageType
 import java.io.ByteArrayInputStream
@@ -14,6 +18,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import javax.imageio.ImageIO
 import kotlin.io.path.exists
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -46,6 +51,11 @@ class ImageOperationTest {
         every { logger.error(any<() -> Any?>()) } answers {
             errorMessages += firstArg<() -> Any?>().invoke().toString()
         }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkObject(DIManager)
     }
 
     @Test
@@ -145,8 +155,6 @@ class ImageOperationTest {
         assertTrue(height > 0)
         assertTrue(width <= 320)
         assertTrue(height <= 320)
-        assertTrue(width < 1080)
-        assertTrue(height < 1920)
 
         assertLogged(debugMessages, "Generated thumbnail in wand")
     }
@@ -184,7 +192,7 @@ class ImageOperationTest {
                 }
             }
 
-        assertTrue(exception.message!!.contains("MagickReadImageBlob"))
+        assertTrue(exception.message.contains("MagickReadImageBlob"))
         assertLogged(errorMessages, "MagickReadImageBlob")
     }
 
@@ -203,7 +211,7 @@ class ImageOperationTest {
                 val exceptionType = ImageOperation.getExceptionType(wand)
                 val exceptionMessage = ImageOperation.getException(wand)
 
-                assertTrue(exception.message!!.contains("MagickWriteImage"))
+                assertTrue(exception.message.contains("MagickWriteImage"))
                 assertTrue(exceptionType > 0)
                 assertTrue(exceptionMessage.contains("no images", ignoreCase = true))
             }
@@ -216,16 +224,25 @@ class ImageOperationTest {
         }
     }
 
-    private fun <T> withNativeContext(block: context(KLogger, Linker, SymbolLookup, Arena) () -> T): T =
+    private fun ensureImageOperationInitialized() {
+        val linker = Linker.nativeLinker()
+        val imageMagickLib = SymbolLookup.libraryLookup(resolveImageMagickLibraryPath(), Arena.global())
+        val di = mockk<DI>()
+        every { di.get(Linker::class) } returns linker
+        every { di.get(SymbolLookup::class) } returns imageMagickLib
+        mockkObject(DIManager)
+        every { DIManager.getDIInstance() } returns di
+    }
+
+    private fun <T> withNativeContext(block: context(KLogger, Arena) () -> T): T =
         Arena.ofConfined().use { arena ->
-            val linker = Linker.nativeLinker()
-            val imageMagickLib = SymbolLookup.libraryLookup(resolveImageMagickLibraryPath(), arena)
-            context(logger, linker, imageMagickLib, arena) {
+            ensureImageOperationInitialized()
+            context(logger, arena) {
                 block()
             }
         }
 
-    private fun <T> withManagedWand(block: context(KLogger, Linker, SymbolLookup, Arena) (MemorySegment) -> T): T =
+    private fun <T> withManagedWand(block: context(KLogger, Arena) (MemorySegment) -> T): T =
         withNativeContext {
             ImageOperation.genesis()
             val wand = ImageOperation.newMagickWand()

--- a/app/src/test/kotlin/io/sakurasou/hoshizora/native/ImageOperationTest.kt
+++ b/app/src/test/kotlin/io/sakurasou/hoshizora/native/ImageOperationTest.kt
@@ -95,6 +95,21 @@ class ImageOperationTest {
     }
 
     @Test
+    fun `getImageFormat width and height should return image metadata`() {
+        withManagedWand { wand ->
+            ImageOperation.readImageBlob(wand, sourceImageBytes)
+
+            assertEquals("PNG", ImageOperation.getImageFormat(wand))
+            assertEquals(1080L, ImageOperation.getImageWidth(wand))
+            assertEquals(1920L, ImageOperation.getImageHeight(wand))
+        }
+
+        assertLogged(debugMessages, "Fetched image format=PNG")
+        assertLogged(debugMessages, "Fetched image width=1080")
+        assertLogged(debugMessages, "Fetched image height=1920")
+    }
+
+    @Test
     fun `resizeImage should resize image and write it to disk`() {
         val tempDir = Files.createTempDirectory("image-operation-resize-test")
         try {

--- a/app/src/test/kotlin/io/sakurasou/hoshizora/native/ImageOperationTest.kt
+++ b/app/src/test/kotlin/io/sakurasou/hoshizora/native/ImageOperationTest.kt
@@ -1,0 +1,290 @@
+package io.sakurasou.hoshizora.native
+
+import io.github.oshai.kotlinlogging.KLogger
+import io.mockk.every
+import io.mockk.mockk
+import io.sakurasou.hoshizora.exception.native.ImageOperationException
+import io.sakurasou.hoshizora.model.group.ImageType
+import java.io.ByteArrayInputStream
+import java.lang.foreign.Arena
+import java.lang.foreign.Linker
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.SymbolLookup
+import java.nio.file.Files
+import java.nio.file.Path
+import javax.imageio.ImageIO
+import kotlin.io.path.exists
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * @author Shiina Kin
+ * 2026/4/10 00:17
+ */
+class ImageOperationTest {
+    private lateinit var logger: KLogger
+    private lateinit var infoMessages: MutableList<String>
+    private lateinit var debugMessages: MutableList<String>
+    private lateinit var errorMessages: MutableList<String>
+
+    @BeforeTest
+    fun setUp() {
+        logger = mockk(relaxed = true)
+        infoMessages = mutableListOf()
+        debugMessages = mutableListOf()
+        errorMessages = mutableListOf()
+
+        every { logger.info(any<() -> Any?>()) } answers {
+            infoMessages += firstArg<() -> Any?>().invoke().toString()
+        }
+        every { logger.debug(any<() -> Any?>()) } answers {
+            debugMessages += firstArg<() -> Any?>().invoke().toString()
+        }
+        every { logger.error(any<() -> Any?>()) } answers {
+            errorMessages += firstArg<() -> Any?>().invoke().toString()
+        }
+    }
+
+    @Test
+    fun `genesis and terminus should log lifecycle messages`() {
+        withNativeContext {
+            ImageOperation.genesis()
+            ImageOperation.terminus()
+        }
+
+        assertLogged(infoMessages, "Initializing ImageMagick runtime")
+        assertLogged(infoMessages, "ImageMagick initialized")
+        assertLogged(infoMessages, "Terminating ImageMagick runtime")
+        assertLogged(infoMessages, "ImageMagick terminated")
+    }
+
+    @Test
+    fun `readImageBlob and getImageBlob should round trip source image`() {
+        val blobBytes =
+            withManagedWand { wand ->
+                ImageOperation.readImageBlob(wand, sourceImageBytes)
+                val blob = ImageOperation.getImageBlob(wand)
+                try {
+                    assertTrue(blob.size > 0)
+                    blob.bytes
+                } finally {
+                    ImageOperation.relinquishMemory(blob.blobPtr)
+                }
+            }
+
+        assertImageDimensions(blobBytes, 1080, 1920)
+
+        assertLogged(debugMessages, "Created MagickWand")
+        assertLogged(debugMessages, "Read image blob into wand")
+        assertLogged(debugMessages, "Fetched image blob from wand")
+        assertLogged(debugMessages, "Relinquished native memory")
+        assertLogged(debugMessages, "Destroyed MagickWand")
+    }
+
+    @Test
+    fun `resizeImage should resize image and write it to disk`() {
+        val tempDir = Files.createTempDirectory("image-operation-resize-test")
+        try {
+            val outputPath = tempDir.resolve("resized.png")
+
+            withManagedWand { wand ->
+                ImageOperation.readImageBlob(wand, sourceImageBytes)
+                ImageOperation.resizeImage(wand, 320, 180)
+                ImageOperation.writeImage(wand, outputPath.toString())
+            }
+
+            assertTrue(outputPath.exists(), "Expected output image to be written")
+            assertImageDimensions(Files.readAllBytes(outputPath), 320, 180)
+
+            assertLogged(debugMessages, "Resized image in wand")
+            assertLogged(debugMessages, "Wrote image from wand")
+        } finally {
+            tempDir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `scaleImage should scale image to target size`() {
+        val blobBytes =
+            withManagedWand { wand ->
+                ImageOperation.readImageBlob(wand, sourceImageBytes)
+                ImageOperation.scaleImage(wand, 160, 90)
+                val blob = ImageOperation.getImageBlob(wand)
+                try {
+                    blob.bytes
+                } finally {
+                    ImageOperation.relinquishMemory(blob.blobPtr)
+                }
+            }
+
+        assertImageDimensions(blobBytes, 160, 90)
+
+        assertLogged(debugMessages, "Scaled image in wand")
+    }
+
+    @Test
+    fun `thumbnailImage should keep aspect ratio within bounds`() {
+        val blobBytes =
+            withManagedWand { wand ->
+                ImageOperation.readImageBlob(wand, sourceImageBytes)
+                ImageOperation.thumbnailImage(wand, 320, 320)
+                val blob = ImageOperation.getImageBlob(wand)
+                try {
+                    blob.bytes
+                } finally {
+                    ImageOperation.relinquishMemory(blob.blobPtr)
+                }
+            }
+
+        val (width, height) = readImageDimensions(blobBytes)
+
+        assertTrue(width > 0)
+        assertTrue(height > 0)
+        assertTrue(width <= 320)
+        assertTrue(height <= 320)
+        assertTrue(width < 1080)
+        assertTrue(height < 1920)
+
+        assertLogged(debugMessages, "Generated thumbnail in wand")
+    }
+
+    @Test
+    fun `setImageFormat and setImageQuality should convert image to jpeg`() {
+        val blobBytes =
+            withManagedWand { wand ->
+                ImageOperation.readImageBlob(wand, sourceImageBytes)
+                ImageOperation.setImageFormat(wand, ImageType.JPEG)
+                ImageOperation.setImageQuality(wand, 0.65)
+                val blob = ImageOperation.getImageBlob(wand)
+                try {
+                    blob.bytes
+                } finally {
+                    ImageOperation.relinquishMemory(blob.blobPtr)
+                }
+            }
+
+        assertTrue(blobBytes.size > 3)
+        assertEquals(0xFF.toByte(), blobBytes[0])
+        assertEquals(0xD8.toByte(), blobBytes[1])
+        assertImageDimensions(blobBytes, 1080, 1920)
+
+        assertLogged(debugMessages, "Set image format for wand")
+        assertLogged(debugMessages, "Set image quality for wand")
+    }
+
+    @Test
+    fun `readImageBlob should throw ImageMagick error for invalid bytes`() {
+        val exception =
+            assertFailsWith<ImageOperationException> {
+                withManagedWand { wand ->
+                    ImageOperation.readImageBlob(wand, byteArrayOf(1, 2, 3, 4))
+                }
+            }
+
+        assertTrue(exception.message!!.contains("MagickReadImageBlob"))
+        assertLogged(errorMessages, "MagickReadImageBlob")
+    }
+
+    @Test
+    fun `writeImage failure should expose exception type and message`() {
+        val tempDir = Files.createTempDirectory("image-operation-exception-test")
+        try {
+            val outputPath = tempDir.resolve("empty.png")
+
+            withManagedWand { wand ->
+                val exception =
+                    assertFailsWith<ImageOperationException> {
+                        ImageOperation.writeImage(wand, outputPath.toString())
+                    }
+
+                val exceptionType = ImageOperation.getExceptionType(wand)
+                val exceptionMessage = ImageOperation.getException(wand)
+
+                assertTrue(exception.message!!.contains("MagickWriteImage"))
+                assertTrue(exceptionType > 0)
+                assertTrue(exceptionMessage.contains("no images", ignoreCase = true))
+            }
+
+            assertLogged(errorMessages, "MagickWriteImage")
+            assertLogged(debugMessages, "Fetched ImageMagick exception type=")
+            assertLogged(debugMessages, "Fetched ImageMagick exception from wand")
+        } finally {
+            tempDir.toFile().deleteRecursively()
+        }
+    }
+
+    private fun <T> withNativeContext(block: context(KLogger, Linker, SymbolLookup, Arena) () -> T): T =
+        Arena.ofConfined().use { arena ->
+            val linker = Linker.nativeLinker()
+            val imageMagickLib = SymbolLookup.libraryLookup(resolveImageMagickLibraryPath(), arena)
+            context(logger, linker, imageMagickLib, arena) {
+                block()
+            }
+        }
+
+    private fun <T> withManagedWand(block: context(KLogger, Linker, SymbolLookup, Arena) (MemorySegment) -> T): T =
+        withNativeContext {
+            ImageOperation.genesis()
+            val wand = ImageOperation.newMagickWand()
+            try {
+                block(wand)
+            } finally {
+                ImageOperation.destroyMagickWand(wand)
+                ImageOperation.terminus()
+            }
+        }
+
+    private fun assertImageDimensions(
+        bytes: ByteArray,
+        expectedWidth: Int,
+        expectedHeight: Int,
+    ) {
+        val (width, height) = readImageDimensions(bytes)
+        assertEquals(expectedWidth, width)
+        assertEquals(expectedHeight, height)
+    }
+
+    private fun readImageDimensions(bytes: ByteArray): Pair<Int, Int> {
+        val image = ImageIO.read(ByteArrayInputStream(bytes))
+        requireNotNull(image) { "Failed to decode image bytes" }
+        return image.width to image.height
+    }
+
+    private fun assertLogged(
+        messages: List<String>,
+        expectedSubstring: String,
+    ) {
+        assertTrue(
+            messages.any { it.contains(expectedSubstring) },
+            "Expected a log containing \"$expectedSubstring\", actual logs=$messages",
+        )
+    }
+
+    private fun resolveImageMagickLibraryPath(): Path {
+        val configuredPath = System.getenv("MAGICK_WAND_LIBRARY")?.takeIf { it.isNotBlank() }?.let(Path::of)
+        val candidates =
+            listOfNotNull(
+                configuredPath,
+                Path.of("/opt/homebrew/lib/libMagickWand-7.Q16HDRI.dylib"),
+                Path.of("/usr/local/lib/libMagickWand-7.Q16HDRI.dylib"),
+                Path.of("/usr/lib/libMagickWand-7.Q16HDRI.so"),
+                Path.of("/usr/lib64/libMagickWand-7.Q16HDRI.so"),
+                Path.of("/lib/aarch64-linux-gnu/libMagickWand-7.Q16HDRI.so"),
+            )
+
+        return candidates.firstOrNull(Files::exists)
+            ?: error("Unable to locate libMagickWand. Set MAGICK_WAND_LIBRARY to the installed library path.")
+    }
+
+    private companion object {
+        private val sourceImageBytes: ByteArray by lazy {
+            ImageOperationTest::class.java.classLoader
+                .getResourceAsStream("test-img.png")
+                ?.readBytes()
+                ?: error("Missing test resource: test-img.png")
+        }
+    }
+}

--- a/app/src/test/kotlin/io/sakurasou/hoshizora/native/ImageOperationTest.kt
+++ b/app/src/test/kotlin/io/sakurasou/hoshizora/native/ImageOperationTest.kt
@@ -184,7 +184,7 @@ class ImageOperationTest {
             withManagedWand { wand ->
                 ImageOperation.readImageBlob(wand, sourceImageBytes)
                 ImageOperation.setImageFormat(wand, ImageType.JPEG)
-                ImageOperation.setImageQuality(wand, 0.65)
+                ImageOperation.setImageQuality(wand, 65)
                 val blob = ImageOperation.getImageBlob(wand)
                 try {
                     blob.bytes
@@ -301,7 +301,8 @@ class ImageOperationTest {
 
     private fun resolveImageMagickLibraryPath(): Path {
         val configuredPath =
-            System.getenv(MAGICK_WAND_LIB_PATH_ENV)
+            System
+                .getenv(MAGICK_WAND_LIB_PATH_ENV)
                 ?.takeIf { it.isNotBlank() }
                 ?.let(Path::of)
                 ?.takeIf(Files::exists)

--- a/compose.yml
+++ b/compose.yml
@@ -24,6 +24,7 @@ services:
       JWT_ISSUER: https://some.issuer
       JWT_AUDIENCE: https://some.audience
       JWT_REALM: hoshizora-pics
+      MAGICK_WAND_LIB_PATH: /opt/imagemagick/lib/libMagickWand-7.Q16HDRI.so
     volumes:
       - hoshizora-pics-data:/hoshizora/images
     networks:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.4.0-Beta1"
-kotlinx-serialization = "1.10.0"
-kotlinx-coroutines = "1.10.２"
+kotlinx-serialization = "1.11.0"
+kotlinx-coroutines = "1.10.2"
 mockk = "1.14.9"
 ktor = "3.4.1"
 exposed = "1.1.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.3.20"
+kotlin = "2.4.0-Beta1"
 kotlinx-serialization = "1.10.0"
 kotlinx-coroutines = "1.10.２"
 mockk = "1.14.9"


### PR DESCRIPTION
This pull request introduces a significant refactor of the image processing pipeline, migrating from the Java-based `im4java` library to direct native ImageMagick integration via the Panama Foreign Function & Memory API. The changes also add robust native library management, graceful shutdown logic, and improve test configuration for native code. The most important changes are grouped below.

**Image Processing Refactor and Native Integration:**

* Completely rewrote `ImageUtils` to use native ImageMagick bindings (via the `ImageOperation` class) instead of the `im4java` library, replacing all usages of `BufferedImage` with `ByteArray` and updating transformation methods to operate with native handles and memory arenas. This enables more efficient, robust, and cross-platform image transformations. [[1]](diffhunk://#diff-554e1e80fbd91a5ed31fa83113b755f74a6fe7c27e42fb25a5eee040ee07ef63R3-R14) [[2]](diffhunk://#diff-554e1e80fbd91a5ed31fa83113b755f74a6fe7c27e42fb25a5eee040ee07ef63R122-R244)
* Updated all image-related tasks (`PersistImageThumbnailTask`, `DeleteImageTask`, `DeleteThumbnailTask`) and `ImageServiceImpl` to use the new native-based image transformation pipeline, ensuring that all image operations are now routed through the new infrastructure. [[1]](diffhunk://#diff-22ffe63ab2e39a04b6ccdc95070b5a6cb0b9fbb014bb9a06fa254821150c7732L14-R28) [[2]](diffhunk://#diff-22ffe63ab2e39a04b6ccdc95070b5a6cb0b9fbb014bb9a06fa254821150c7732R50-R71) [[3]](diffhunk://#diff-22ffe63ab2e39a04b6ccdc95070b5a6cb0b9fbb014bb9a06fa254821150c7732R84-R86) [[4]](diffhunk://#diff-22ffe63ab2e39a04b6ccdc95070b5a6cb0b9fbb014bb9a06fa254821150c7732R101-R103) [[5]](diffhunk://#diff-1841e630768431efd9238cfddb33b0f73b9acab235fb32cf52bcb3479af70ca7L113-R134)
* Added a custom exception `ImageOperationException` for native image operation errors, improving error handling and debuggability.

**Native Library Initialization and Management:**

* Modified application startup (`Application.kt` and `InstanceCenter.kt`) to require and validate the path to the native ImageMagick library, and to register the necessary Panama linker and symbol lookup objects for native calls. [[1]](diffhunk://#diff-62c92792875c6005e1a0d2613d23f5db6b026f80e77ef89cb76fd6d86b67e3a7R21-R29) [[2]](diffhunk://#diff-62c92792875c6005e1a0d2613d23f5db6b026f80e77ef89cb76fd6d86b67e3a7R40-R42) [[3]](diffhunk://#diff-62c92792875c6005e1a0d2613d23f5db6b026f80e77ef89cb76fd6d86b67e3a7L43-R53) [[4]](diffhunk://#diff-1e30afaf96c5fa18671eedaa06095d09cd58d96fde92752c64614e74cfb2abd2R3-R11) [[5]](diffhunk://#diff-1e30afaf96c5fa18671eedaa06095d09cd58d96fde92752c64614e74cfb2abd2R35) [[6]](diffhunk://#diff-1e30afaf96c5fa18671eedaa06095d09cd58d96fde92752c64614e74cfb2abd2R60-R73) [[7]](diffhunk://#diff-1e30afaf96c5fa18671eedaa06095d09cd58d96fde92752c64614e74cfb2abd2R98-R99)
* Added a graceful shutdown hook that cleans up native and coroutine resources, ensuring proper resource release on application exit. [[1]](diffhunk://#diff-62c92792875c6005e1a0d2613d23f5db6b026f80e77ef89cb76fd6d86b67e3a7R21-R29) [[2]](diffhunk://#diff-1e30afaf96c5fa18671eedaa06095d09cd58d96fde92752c64614e74cfb2abd2R124-R131) [[3]](diffhunk://#diff-55a4a483366b077b0e2adb452a41e7928b323368b86f74d965192d3b7c36c1afR73-R76)

**Testing and Build Improvements:**

* Updated the Kotlin plugin version to `2.4.0-Beta1` and added a JVM argument to enable native access for all unnamed modules during tests, which is required for Panama native interop. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L33-R33) [[2]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R128-R131)

(References: [[1]](diffhunk://#diff-554e1e80fbd91a5ed31fa83113b755f74a6fe7c27e42fb25a5eee040ee07ef63R3-R14) [[2]](diffhunk://#diff-554e1e80fbd91a5ed31fa83113b755f74a6fe7c27e42fb25a5eee040ee07ef63R122-R244) [[3]](diffhunk://#diff-22ffe63ab2e39a04b6ccdc95070b5a6cb0b9fbb014bb9a06fa254821150c7732L14-R28) [[4]](diffhunk://#diff-22ffe63ab2e39a04b6ccdc95070b5a6cb0b9fbb014bb9a06fa254821150c7732R50-R71) [[5]](diffhunk://#diff-22ffe63ab2e39a04b6ccdc95070b5a6cb0b9fbb014bb9a06fa254821150c7732R84-R86) [[6]](diffhunk://#diff-22ffe63ab2e39a04b6ccdc95070b5a6cb0b9fbb014bb9a06fa254821150c7732R101-R103) [[7]](diffhunk://#diff-1841e630768431efd9238cfddb33b0f73b9acab235fb32cf52bcb3479af70ca7L113-R134) [[8]](diffhunk://#diff-093d1c7d58a29cd29108d921c3dd6bf1ec1d3d15dac8f53ac712418b715d409bR1-R14) [[9]](diffhunk://#diff-62c92792875c6005e1a0d2613d23f5db6b026f80e77ef89cb76fd6d86b67e3a7R21-R29) [[10]](diffhunk://#diff-62c92792875c6005e1a0d2613d23f5db6b026f80e77ef89cb76fd6d86b67e3a7R40-R42) [[11]](diffhunk://#diff-62c92792875c6005e1a0d2613d23f5db6b026f80e77ef89cb76fd6d86b67e3a7L43-R53) [[12]](diffhunk://#diff-1e30afaf96c5fa18671eedaa06095d09cd58d96fde92752c64614e74cfb2abd2R3-R11) [[13]](diffhunk://#diff-1e30afaf96c5fa18671eedaa06095d09cd58d96fde92752c64614e74cfb2abd2R35) [[14]](diffhunk://#diff-1e30afaf96c5fa18671eedaa06095d09cd58d96fde92752c64614e74cfb2abd2R60-R73) [[15]](diffhunk://#diff-1e30afaf96c5fa18671eedaa06095d09cd58d96fde92752c64614e74cfb2abd2R98-R99) [[16]](diffhunk://#diff-1e30afaf96c5fa18671eedaa06095d09cd58d96fde92752c64614e74cfb2abd2R124-R131) [[17]](diffhunk://#diff-55a4a483366b077b0e2adb452a41e7928b323368b86f74d965192d3b7c36c1afR73-R76) [[18]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L33-R33) [[19]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R128-R131)